### PR TITLE
angle is now numerically stable

### DIFF
--- a/src/Quaternion.jl
+++ b/src/Quaternion.jl
@@ -93,7 +93,7 @@ end
 
 angleaxis(q::Quaternion) = angle(q), axis(q)
 
-angle(q::Quaternion) = 2 * acos(real(normalize(q)))
+angle(q::Quaternion) = 2*atan2(√(q.v1^2 + q.v2^2 + q.v3^2), q.s)
 
 function axis(q::Quaternion)
     q = normalize(q)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,34 +1,53 @@
 using Base.Test
 using Quaternions
 
-qx = qrotation([1,0,0], pi/4)
-@test_approx_eq qx*qx qrotation([1,0,0], pi/2)
-@test_approx_eq qx^2 qrotation([1,0,0], pi/2)
-theta = pi/8
-qx = qrotation([1,0,0], theta)
-c = cos(theta); s = sin(theta)
-Rx = [1 0 0; 0 c -s; 0 s c]
-@test_approx_eq rotationmatrix(qx) Rx
-theta = pi/6
-qy = qrotation([0,1,0], theta)
-c = cos(theta); s = sin(theta)
-Ry = [c 0 s; 0 1 0; -s 0 c]
-@test_approx_eq rotationmatrix(qy) Ry
-theta = 4pi/3
-qz = qrotation([0,0,1], theta)
-c = cos(theta); s = sin(theta)
-Rz = [c -s 0; s c 0; 0 0 1]
-@test_approx_eq rotationmatrix(qz) Rz
+let # test rotations
+    qx = qrotation([1,0,0], pi/4)
+    @test_approx_eq qx*qx qrotation([1,0,0], pi/2)
+    @test_approx_eq qx^2 qrotation([1,0,0], pi/2)
+    theta = pi/8
+    qx = qrotation([1,0,0], theta)
+    c = cos(theta); s = sin(theta)
+    Rx = [1 0 0; 0 c -s; 0 s c]
+    @test_approx_eq rotationmatrix(qx) Rx
+    theta = pi/6
+    qy = qrotation([0,1,0], theta)
+    c = cos(theta); s = sin(theta)
+    Ry = [c 0 s; 0 1 0; -s 0 c]
+    @test_approx_eq rotationmatrix(qy) Ry
+    theta = 4pi/3
+    qz = qrotation([0,0,1], theta)
+    c = cos(theta); s = sin(theta)
+    Rz = [c -s 0; s c 0; 0 0 1]
+    @test_approx_eq rotationmatrix(qz) Rz
 
-@test_approx_eq rotationmatrix(qx*qy*qz) Rx*Ry*Rz
-@test_approx_eq rotationmatrix(qy*qx*qz) Ry*Rx*Rz
-@test_approx_eq rotationmatrix(qz*qx*qy) Rz*Rx*Ry
+    @test_approx_eq rotationmatrix(qx*qy*qz) Rx*Ry*Rz
+    @test_approx_eq rotationmatrix(qy*qx*qz) Ry*Rx*Rz
+    @test_approx_eq rotationmatrix(qz*qx*qy) Rz*Rx*Ry
 
-a, b = qrotation([0,0,1], deg2rad(0)), qrotation([0,0,1], deg2rad(180))
-@test_approx_eq slerp(a,b,0.0) a
-@test_approx_eq slerp(a,b,1.0) b
-@test_approx_eq slerp(a,b,0.5) qrotation([0,0,1], deg2rad(90))
+    a, b = qrotation([0,0,1], deg2rad(0)), qrotation([0,0,1], deg2rad(180))
+    @test_approx_eq slerp(a,b,0.0) a
+    @test_approx_eq slerp(a,b,1.0) b
+    @test_approx_eq slerp(a,b,0.5) qrotation([0,0,1], deg2rad(90))
 
-@test_approx_eq angle(qrotation([1,0,0], 0)) 0
-@test_approx_eq angle(qrotation([0,1,0], pi/4)) pi/4
-@test_approx_eq angle(qrotation([0,0,1], pi/2)) pi/2
+    @test_approx_eq angle(qrotation([1,0,0], 0)) 0
+    @test_approx_eq angle(qrotation([0,1,0], pi/4)) pi/4
+    @test_approx_eq angle(qrotation([0,0,1], pi/2)) pi/2
+
+    # test qrotation and angleaxis inverse
+    for _ in 1:100
+        ax = randn(3); ax = ax/norm(ax)
+        Θ = π * rand()
+        q = qrotation(ax, Θ)
+        @test_approx_eq angle(q) Θ
+        @test_approx_eq axis(q) ax
+    end
+
+    let # test numerical stability of angle
+        ax = randn(3)
+        for θ in [1e-9, π - 1e-9]
+            q = qrotation(ax, θ)
+            @test_approx_eq angle(q) θ
+        end
+    end
+end


### PR DESCRIPTION
The current `angle` method (called `angle_fast` in the following) is numerically instable:

```
using Quaternions

angle_stable(q::Quaternion) = 2*atan2(√(q.v1^2 + q.v2^2 + q.v3^2), q.s)
angle_fast(q::Quaternion) = 2 * acos(real(normalize(q)))

ax = randn(3)
θ = 1e-8
q = qrotation(ax, θ)
@show θ
@show angle_stable(q)
@show angle_fast(q)
```
```
θ = 1.0e-8
angle_stable(q) = 1.0e-8
angle_fast(q) = 0.0
```

I replaced it with `angle_stable`, which is s̶̶l̶̶o̶̶w̶̶e̶̶r̶ as fast:

```
using BenchmarkTools

q = Quaternion(randn(4)...)
println(median(@benchmark angle_stable($q)))
println(median(@benchmark angle_fast($q)))

BenchmarkTools.TrialEstimate: 
  time:             21.00 ns
  gctime:           0.00 ns (0.00%)
  memory:           0.00 bytes
  allocs:           0
  time tolerance:   5.00%
  memory tolerance: 1.00%
BenchmarkTools.TrialEstimate: 
  time:             23.00 ns
  gctime:           0.00 ns (0.00%)
  memory:           0.00 bytes
  allocs:           0
  time tolerance:   5.00%
  memory tolerance: 1.00%
```