### PR TITLE
Drop Julia 0.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ os:
   - linux
   - osx
 julia:
-  - 0.3
   - 0.4
+  - 0.5
   - nightly
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: julia
 os:
   - linux
-  - osx
 julia:
   - 0.4
   - 0.5

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.3
+julia 0.4
 
 DualNumbers
 Compat 0.7.15


### PR DESCRIPTION
This is a rebased version of #17. 

Note: this also turns OFF osx builds on Travis. I'm happy to revert that change if you like, but I don't think there's much benefit to testing pure-julia packages like this on OSX as well as linux (and Travis's OSX machines are a relatively scarce resource). The benefit (in addition to being kind to Travis's servers) should be faster build times. 