### PR TITLE
add funcs to work with GenericSVD

### DIFF
--- a/src/DualQuaternion.jl
+++ b/src/DualQuaternion.jl
@@ -34,7 +34,7 @@ convert(::Type{DualQuaternion{T}}, q::DualQuaternion{T}) where {T <: Real} = q
 
 convert(::Type{DualQuaternion{T}}, dq::DualQuaternion) where {T} =
     DualQuaternion(convert(Quaternion{T}, dq.q0), convert(Quaternion{T}, dq.qe), dq.norm)
-convert(::Type{DualQuaternion{T}}, b::Bool) = x ? one(DualQuaternion{T}) : zero(DualQuaternion{T})
+convert(::Type{DualQuaternion{T}}, b::Bool) where {T} = b ? one(DualQuaternion{T}) : zero(DualQuaternion{T})
 
 promote_rule(::Type{DualQuaternion{T}}, ::Type{T}) where {T <: Real} = DualQuaternion{T}
 promote_rule(::Type{DualQuaternion}, ::Type{T}) where {T <: Real} = DualQuaternion

--- a/src/DualQuaternion.jl
+++ b/src/DualQuaternion.jl
@@ -34,6 +34,7 @@ convert(::Type{DualQuaternion{T}}, q::DualQuaternion{T}) where {T <: Real} = q
 
 convert(::Type{DualQuaternion{T}}, dq::DualQuaternion) where {T} =
     DualQuaternion(convert(Quaternion{T}, dq.q0), convert(Quaternion{T}, dq.qe), dq.norm)
+
 convert(::Type{DualQuaternion{T}}, b::Bool) where {T} = b ? one(DualQuaternion{T}) : zero(DualQuaternion{T})
 
 promote_rule(::Type{DualQuaternion{T}}, ::Type{T}) where {T <: Real} = DualQuaternion{T}

--- a/src/DualQuaternion.jl
+++ b/src/DualQuaternion.jl
@@ -34,6 +34,7 @@ convert(::Type{DualQuaternion{T}}, q::DualQuaternion{T}) where {T <: Real} = q
 
 convert(::Type{DualQuaternion{T}}, dq::DualQuaternion) where {T} =
     DualQuaternion(convert(Quaternion{T}, dq.q0), convert(Quaternion{T}, dq.qe), dq.norm)
+convert(::Type{DualQuaternion{T}}, b::Bool) = x ? one(DualQuaternion{T}) : zero(DualQuaternion{T})
 
 promote_rule(::Type{DualQuaternion{T}}, ::Type{T}) where {T <: Real} = DualQuaternion{T}
 promote_rule(::Type{DualQuaternion}, ::Type{T}) where {T <: Real} = DualQuaternion
@@ -54,6 +55,11 @@ end
 
 Q0(dq::DualQuaternion) = dq.q0
 Qe(dq::DualQuaternion) = dq.qe
+
+zero(::Type{DualQuaternion{T}}) where {T} = DualQuaternion(zero(Quaternion{T}), zero(Quaternion{T}))
+one(::Type{DualQuaternion{T}}) where {T} = DualQuaternion(one(Quaternion{T}), zero(Quaternion{T}))
+iszero(dq::DualQuaternion{T}) where {T} = dq === zero(DualQuaternion{T})
+isone(dq::DualQuaternion{T}) where {T} = dq === one(DualQuaternion{T})
 
 (/)(dq::DualQuaternion, x::Real) = DualQuaternion(dq.q0 / x, dq.qe / x)
 

--- a/src/Octonion.jl
+++ b/src/Octonion.jl
@@ -27,7 +27,7 @@ convert(::Type{Octonion{T}}, q::Quaternion) where {T} =
 convert(::Type{Octonion{T}}, o::Octonion{T}) where {T <: Real} = o
 convert(::Type{Octonion{T}}, o::Octonion) where {T} =
   Octonion(convert(T, o.s), convert(T, o.v1), convert(T, o.v2), convert(T, o.v3), convert(T, o.v4), convert(T, o.v5), convert(T, o.v6), convert(T, o.v7), o.norm)
-convert(::Type{Octonion{T}}, x::Bool) where {T} = x ? one(Octonion{T}) : zero(Octonion{T})
+convert(::Type{Octonion{T}}, b::Bool) where {T} = b ? one(Octonion{T}) : zero(Octonion{T})
 
 promote_rule(::Type{Octonion{T}}, ::Type{T}) where {T <: Real} = Octonion{T}
 promote_rule(::Type{Octonion}, ::Type{T}) where {T <: Real} = Octonion

--- a/src/Octonion.jl
+++ b/src/Octonion.jl
@@ -27,6 +27,7 @@ convert(::Type{Octonion{T}}, q::Quaternion) where {T} =
 convert(::Type{Octonion{T}}, o::Octonion{T}) where {T <: Real} = o
 convert(::Type{Octonion{T}}, o::Octonion) where {T} =
   Octonion(convert(T, o.s), convert(T, o.v1), convert(T, o.v2), convert(T, o.v3), convert(T, o.v4), convert(T, o.v5), convert(T, o.v6), convert(T, o.v7), o.norm)
+convert(::Type{Octonion{T}}, x::Bool) where {T} = x ? one(Octonion{T}) : zero(Octonion{T})
 
 promote_rule(::Type{Octonion{T}}, ::Type{T}) where {T <: Real} = Octonion{T}
 promote_rule(::Type{Octonion}, ::Type{T}) where {T <: Real} = Octonion
@@ -44,8 +45,14 @@ function show(io::IO, o::Octonion)
   print(io, o.s, pm(o.v1), "im", pm(o.v2), "jm", pm(o.v3), "km", pm(o.v4), "ilm", pm(o.v5), "jlm", pm(o.v6), "klm", pm(o.v7), "lm")
 end
 
+real(::Type{Octonion{T}}) where {T} = T
 real(o::Octonion) = o.s
 imag(o::Octonion) = [o.v1, o.v2, o.v3, o.v4, o.v5, o.v6, o.v7]
+
+zero(::Type{Octonion{T}}) where {T} = Octonion(zero(T), zero(T), zero(T), zero(T), zero(T), zero(T), zero(T), zero(T))
+one(::Type{Octonion{T}}) where {T} = Octonion(one(T), zero(T), zero(T), zero(T), zero(T), zero(T), zero(T), zero(T))
+iszero(o::Octonion{T}) where {T} = o === zero(Octonion{T})
+isone(o::Octonion{T}) where {T} = o === one(Octonion{T})
 
 (/)(o::Octonion, x::Real) = Octonion(o.s / x, o.v1 / x, o.v2 / x, o.v3 / x, o.v4 / x, o.v5 / x, o.v6 / x, o.v7 / x)
 

--- a/src/Quaternion.jl
+++ b/src/Quaternion.jl
@@ -23,7 +23,7 @@ convert(::Type{Quaternion{T}}, z::Complex) where {T} =
 convert(::Type{Quaternion{T}}, q::Quaternion{T}) where {T <: Real} = q
 convert(::Type{Quaternion{T}}, q::Quaternion) where {T} =
     Quaternion(convert(T, q.s), convert(T, q.v1), convert(T, q.v2), convert(T, q.v3), q.norm)
-convert(::Type{Quaternion{T}}, x::Bool) where {T} = x ? one(Quaternion{T} : zero(Quaternion{T})
+convert(::Type{Quaternion{T}}, x::Bool) where {T} = x ? one(Quaternion{T}) : zero(Quaternion{T})
 
 promote_rule(::Type{Quaternion{T}}, ::Type{T}) where {T <: Real} = Quaternion{T}
 promote_rule(::Type{Quaternion}, ::Type{T}) where {T <: Real} = Quaternion

--- a/src/Quaternion.jl
+++ b/src/Quaternion.jl
@@ -23,7 +23,7 @@ convert(::Type{Quaternion{T}}, z::Complex) where {T} =
 convert(::Type{Quaternion{T}}, q::Quaternion{T}) where {T <: Real} = q
 convert(::Type{Quaternion{T}}, q::Quaternion) where {T} =
     Quaternion(convert(T, q.s), convert(T, q.v1), convert(T, q.v2), convert(T, q.v3), q.norm)
-convert(::Type{Quaternion{T}}, x::Bool) where {T} = x ? one(Quaternion{T}) : zero(Quaternion{T})
+convert(::Type{Quaternion{T}}, b::Bool) where {T} = b ? one(Quaternion{T}) : zero(Quaternion{T})
 
 promote_rule(::Type{Quaternion{T}}, ::Type{T}) where {T <: Real} = Quaternion{T}
 promote_rule(::Type{Quaternion}, ::Type{T}) where {T <: Real} = Quaternion

--- a/src/Quaternion.jl
+++ b/src/Quaternion.jl
@@ -46,8 +46,8 @@ imag(q::Quaternion) = [q.v1, q.v2, q.v3]
 
 zero(::Type{Quaternion{T}}) where {T} = Quaternion(zero(T), zero(T), zero(T), zero(T))
 one(::Type{Quaternion{T}}) where {T} = Quaternion(one(T), zero(T), zero(T), zero(T))
-iszero(q::Quaternion{T}) where {T} = q === zero(Quaternion{T])
-isone(q::Quaternion{T}) where {T} = q === one(Quaternion{T])
+iszero(q::Quaternion{T}) where {T} = q === zero(Quaternion{T})
+isone(q::Quaternion{T}) where {T} = q === one(Quaternion{T})
 
 (/)(q::Quaternion, x::Real) = Quaternion(q.s / x, q.v1 / x, q.v2 / x, q.v3 / x)
 

--- a/src/Quaternion.jl
+++ b/src/Quaternion.jl
@@ -23,6 +23,7 @@ convert(::Type{Quaternion{T}}, z::Complex) where {T} =
 convert(::Type{Quaternion{T}}, q::Quaternion{T}) where {T <: Real} = q
 convert(::Type{Quaternion{T}}, q::Quaternion) where {T} =
     Quaternion(convert(T, q.s), convert(T, q.v1), convert(T, q.v2), convert(T, q.v3), q.norm)
+convert(::Type{Quaternion{T}}, x::Bool) where {T} = x ? one(Quaternion{T} : zero(Quaternion{T})
 
 promote_rule(::Type{Quaternion{T}}, ::Type{T}) where {T <: Real} = Quaternion{T}
 promote_rule(::Type{Quaternion}, ::Type{T}) where {T <: Real} = Quaternion
@@ -42,6 +43,11 @@ end
 real(::Type{Quaternion{T}}) where {T} = T
 real(q::Quaternion) = q.s
 imag(q::Quaternion) = [q.v1, q.v2, q.v3]
+
+zero(::Type{Quaternion{T}}) where {T} = Quaternion(zero(T), zero(T), zero(T), zero(T))
+one(::Type{Quaternion{T}}) where {T} = Quaternion(one(T), zero(T), zero(T), zero(T))
+iszero(q::Quaternion{T}) where {T} = q === zero(Quaternion{T])
+isone(q::Quaternion{T}) where {T} = q === one(Quaternion{T])
 
 (/)(q::Quaternion, x::Real) = Quaternion(q.s / x, q.v1 / x, q.v2 / x, q.v3 / x)
 

--- a/src/Quaternions.jl
+++ b/src/Quaternions.jl
@@ -4,6 +4,7 @@ module Quaternions
 
   using Compat
 
+  import Base: zero, one, iszero, isone
   import Base: +, -, *, /, ^
   import Base: abs, abs2, angle, conj, cos, exp, inv, isfinite, log, real, sin, sqrt
   import Base: convert, promote_rule


### PR DESCRIPTION
I added convert(T, x::Bool) with supporting zero(T), one(T) and in kind iszero(x) isone(x).
With this, doing
```julia
using Quaternions
import GenericSVD.svd

svd( <matrix of T> ) where T<:Q,O,DQ
```
should just work 