### PR TITLE
add float function

### DIFF
--- a/src/DualQuaternion.jl
+++ b/src/DualQuaternion.jl
@@ -34,6 +34,7 @@ convert(::Type{DualQuaternion{T}}, q::DualQuaternion{T}) where {T <: Real} = q
 
 convert(::Type{DualQuaternion{T}}, dq::DualQuaternion) where {T} =
     DualQuaternion(convert(Quaternion{T}, dq.q0), convert(Quaternion{T}, dq.qe), dq.norm)
+float(q::DualQuaternion{T}) where T = DualQuaternion(float(q.q0), float(q.qe), q.norm)
 
 promote_rule(::Type{DualQuaternion{T}}, ::Type{T}) where {T <: Real} = DualQuaternion{T}
 promote_rule(::Type{DualQuaternion}, ::Type{T}) where {T <: Real} = DualQuaternion

--- a/src/Octonion.jl
+++ b/src/Octonion.jl
@@ -27,6 +27,7 @@ convert(::Type{Octonion{T}}, q::Quaternion) where {T} =
 convert(::Type{Octonion{T}}, o::Octonion{T}) where {T <: Real} = o
 convert(::Type{Octonion{T}}, o::Octonion) where {T} =
   Octonion(convert(T, o.s), convert(T, o.v1), convert(T, o.v2), convert(T, o.v3), convert(T, o.v4), convert(T, o.v5), convert(T, o.v6), convert(T, o.v7), o.norm)
+float(o::Octonion{T}) where T = Octonion(float(o.s), float(o.v1), float(o.v2), float(o.v3), float(o.v4), float(o.v5), float(o.v6), float(o.v7), o.norm)
 
 promote_rule(::Type{Octonion{T}}, ::Type{T}) where {T <: Real} = Octonion{T}
 promote_rule(::Type{Octonion}, ::Type{T}) where {T <: Real} = Octonion

--- a/src/Quaternion.jl
+++ b/src/Quaternion.jl
@@ -23,6 +23,7 @@ convert(::Type{Quaternion{T}}, z::Complex) where {T} =
 convert(::Type{Quaternion{T}}, q::Quaternion{T}) where {T <: Real} = q
 convert(::Type{Quaternion{T}}, q::Quaternion) where {T} =
     Quaternion(convert(T, q.s), convert(T, q.v1), convert(T, q.v2), convert(T, q.v3), q.norm)
+float(q::Quaternion{T}) where T = Quaternion(float(q.s), float(q.v1), float(q.v2), float(q.v3), q.norm)
 
 promote_rule(::Type{Quaternion{T}}, ::Type{T}) where {T <: Real} = Quaternion{T}
 promote_rule(::Type{Quaternion}, ::Type{T}) where {T <: Real} = Quaternion

--- a/src/Quaternions.jl
+++ b/src/Quaternions.jl
@@ -6,7 +6,7 @@ module Quaternions
 
   import Base: +, -, *, /, ^
   import Base: abs, abs2, angle, conj, cos, exp, inv, isfinite, log, real, sin, sqrt
-  import Base: convert, promote_rule
+  import Base: convert, float, promote_rule
   import Compat.LinearAlgebra: norm, normalize
 
   include("Quaternion.jl")


### PR DESCRIPTION
This is needed for `norm(::Quaternion)` and, for instance, for approximate matrix comparisons on Julia v1.2. I haven't added any tests, since there are currently no conversion tests.

Edit: BTW, are all those `Compat` things still necessary? I haven't seen that for a while.
Edit2: Oh, is that because Quaternions.jl is supposed to work for Julia v0.6 to nightly?