### PR TITLE
Accept inputting `AbstractVector` and `AbstractMatrix`.

### DIFF
--- a/src/Quaternion.jl
+++ b/src/Quaternion.jl
@@ -17,8 +17,8 @@ Quaternion(s::Real, v1::Real, v2::Real, v3::Real, n::Bool = false) =
     Quaternion(promote(s, v1, v2, v3)..., n)
 Quaternion(x::Real) = Quaternion(x, zero(x), zero(x), zero(x), abs(x) == one(x))
 Quaternion(z::Complex) = Quaternion(z.re, z.im, zero(z.re), zero(z.re), abs(z) == one(z.re))
-Quaternion(s::Real, a::Vector) = Quaternion(s, a[1], a[2], a[3])
-Quaternion(a::Vector) = Quaternion(0, a[1], a[2], a[3])
+Quaternion(s::Real, a::AbstractVector) = Quaternion(s, a[1], a[2], a[3])
+Quaternion(a::AbstractVector) = Quaternion(0, a[1], a[2], a[3])
 
 convert(::Type{Quaternion{T}}, x::Real) where {T} = Quaternion(convert(T, x))
 convert(::Type{Quaternion{T}}, z::Complex) where {T} = Quaternion(convert(Complex{T}, z))
@@ -287,7 +287,7 @@ end
 
 ## Rotations
 
-function qrotation(axis::Vector{T}, theta) where {T <: Real}
+function qrotation(axis::AbstractVector{T}, theta) where {T <: Real}
     if length(axis) != 3
         error("Must be a 3-vector")
     end
@@ -302,7 +302,7 @@ function qrotation(axis::Vector{T}, theta) where {T <: Real}
 end
 
 # Variant of the above where norm(rotvec) encodes theta
-function qrotation(rotvec::Vector{T}) where {T <: Real}
+function qrotation(rotvec::AbstractVector{T}) where {T <: Real}
     if length(rotvec) != 3
         error("Must be a 3-vector")
     end
@@ -312,7 +312,7 @@ function qrotation(rotvec::Vector{T}) where {T <: Real}
     Quaternion(c, scaleby * rotvec[1], scaleby * rotvec[2], scaleby * rotvec[3], true)
 end
 
-function qrotation(dcm::Matrix{T}) where {T<:Real}
+function qrotation(dcm::AbstractMatrix{T}) where {T<:Real}
     # See https://arxiv.org/pdf/math/0701759.pdf
     a2 = 1 + dcm[1,1] + dcm[2,2] + dcm[3,3]
     b2 = 1 + dcm[1,1] - dcm[2,2] - dcm[3,3]
@@ -334,7 +334,7 @@ function qrotation(dcm::Matrix{T}) where {T<:Real}
     end
 end
 
-function qrotation(dcm::Matrix{T}, qa::Quaternion) where {T<:Real}
+function qrotation(dcm::AbstractMatrix{T}, qa::Quaternion) where {T<:Real}
     q = qrotation(dcm)
     abs(q-qa) < abs(q+qa) ? q : -q
 end

--- a/test/Quaternion.jl
+++ b/test/Quaternion.jl
@@ -17,6 +17,8 @@ Base.:(/)(a::MyReal, b::Real) = a.val / b
 
     @testset "Constructors" begin
         @test Quaternion{Float64}(1) === Quaternion(1.0) # explicit type construction
+        @test Quaternion(1, [1, 2, 3]) === Quaternion(1, 1, 2, 3)
+        @test Quaternion([1, 2, 3]) === Quaternion(0, 1, 2, 3)
     end
 
     @testset "==" begin
@@ -334,7 +336,7 @@ Base.:(/)(a::MyReal, b::Real) = a.val / b
             @test qrotation([0, 0, 0], 1.0) == Quaternion(1.0) # a zero axis should act like zero rotation
             @test qrotation([1, 0, 0], 0.0) == Quaternion(1.0)
             @test qrotation([0, 0, 0]) == Quaternion(1.0)
-            qx = qrotation([1, 0, 0], pi / 4)
+            qx = qrotation(view([1, 0, 0], :), pi / 4)
             @test qx * qx ≈ qrotation([1, 0, 0], pi / 2)
             @test qx^2 ≈ qrotation([1, 0, 0], pi / 2)
 


### PR DESCRIPTION
  Replaced `Vector`/`Matrix` with `AbstractVector`/`AbstractMatrix` to support creating quaternions from `view`s.

```julia-repl
julia> using Quaternions
julia> U, Φ = randn(5,3,4), randn(5,1,4);
julia> u, ϕ = view(U, 1,:,1), view(Φ, 1,:,1)[1];
julia> q = qrotation(u, ϕ)
```

------------
The `DualNumbers.jl` doesn't treat a 0-dimensional `AbstractArray` as a `Number`, hence the demo above has `ϕ = view(Φ, 1,:,1)[1]`.