### PR TITLE
Remove unnecessary type conversion inside `qrotation`

### DIFF
--- a/src/Quaternion.jl
+++ b/src/Quaternion.jl
@@ -194,9 +194,8 @@ function qrotation(axis::Vector{T}, theta) where {T <: Real}
         error("Must be a 3-vector")
     end
     u = normalize(axis)
-    thetaT = convert(eltype(u), theta)
-    s = sin(thetaT / 2)
-    Quaternion(cos(thetaT / 2), s * u[1], s * u[2], s * u[3], true)
+    s = sin(theta / 2)
+    Quaternion(cos(theta / 2), s * u[1], s * u[2], s * u[3], true)
 end
 
 # Variant of the above where norm(rotvec) encodes theta

--- a/test/test_Quaternion.jl
+++ b/test/test_Quaternion.jl
@@ -57,6 +57,14 @@ let # test rotations
     @test angle(qrotation([0, 1, 0], pi / 4)) ≈ pi / 4
     @test angle(qrotation([0, 0, 1], pi / 2)) ≈ pi / 2
 
+    # Regression test for
+    # https://github.com/JuliaGeometry/Quaternions.jl/issues/8#issuecomment-610640094
+    struct MyReal <: Real
+      val::Real
+    end
+    Base.:(/)(a::MyReal, b::Real) = a.val / b
+    @test qrotation([1, 0, 0], MyReal(1.5)) != "this used to throw an error"
+
     let # test numerical stability of angle
         ax = randn(3)
         for θ in [1e-9, π - 1e-9]

--- a/test/test_Quaternion.jl
+++ b/test/test_Quaternion.jl
@@ -63,7 +63,8 @@ let # test rotations
       val::Real
     end
     Base.:(/)(a::MyReal, b::Real) = a.val / b
-    @test qrotation([1, 0, 0], MyReal(1.5)) != "this used to throw an error"
+    # this used to throw an error
+    qrotation([1, 0, 0], MyReal(1.5))
 
     let # test numerical stability of angle
         ax = randn(3)


### PR DESCRIPTION
# Summary

Addresses https://github.com/JuliaGeometry/Quaternions.jl/issues/8#issuecomment-610640094 by removing the conversion.

## Tested

Added a regression test that fails without the code change.