### PR TITLE
Fix conversion of `Complex` to `Quaternion`/`Octonion`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Quaternions"
 uuid = "94ee1d12-ae83-5a48-8b1c-48b8ff168ae0"
-version = "0.4.1"
+version = "0.4.2"
 
 [deps]
 DualNumbers = "fa6b7ba4-c1ee-5f82-b5fc-ecf0adba8f74"

--- a/src/Octonion.jl
+++ b/src/Octonion.jl
@@ -21,7 +21,7 @@ Octonion(a::Vector) = Octonion(0, a[1], a[2], a[3], a[4], a[5], a[6], a[7])
 convert(::Type{Octonion{T}}, x::Real) where {T} =
   Octonion(convert(T, x), convert(T, 0), convert(T, 0), convert(T, 0), convert(T, 0), convert(T, 0), convert(T, 0), convert(T, 0))
 convert(::Type{Octonion{T}}, z::Complex) where {T} =
-  Octonion(convert(T, real(z)), convert(T, imag(z)), convert(T, 0), convert(T, 0), convert(T, 0), convert(T, 0), convert(T, 0), convert(T, 0))
+  Octonion(convert(T, real(z)), convert(T, Base.imag(z)), convert(T, 0), convert(T, 0), convert(T, 0), convert(T, 0), convert(T, 0), convert(T, 0))
 convert(::Type{Octonion{T}}, q::Quaternion) where {T} =
   Octonion(convert(T, real(q)), convert(T, q.v1), convert(T, q.v2), convert(T, q.v3), convert(T, 0), convert(T, 0), convert(T, 0), convert(T, 0))
 convert(::Type{Octonion{T}}, o::Octonion{T}) where {T <: Real} = o

--- a/src/Quaternion.jl
+++ b/src/Quaternion.jl
@@ -19,7 +19,7 @@ Quaternion(a::Vector) = Quaternion(0, a[1], a[2], a[3])
 convert(::Type{Quaternion{T}}, x::Real) where {T} =
     Quaternion(convert(T, x), convert(T, 0), convert(T, 0), convert(T, 0))
 convert(::Type{Quaternion{T}}, z::Complex) where {T} =
-    Quaternion(convert(T, real(z)), convert(T, imag(z)), convert(T, 0), convert(T, 0))
+    Quaternion(convert(T, real(z)), convert(T, Base.imag(z)), convert(T, 0), convert(T, 0))
 convert(::Type{Quaternion{T}}, q::Quaternion{T}) where {T <: Real} = q
 convert(::Type{Quaternion{T}}, q::Quaternion) where {T} =
     Quaternion(convert(T, q.s), convert(T, q.v1), convert(T, q.v2), convert(T, q.v3), q.norm)

--- a/test/test_Quaternion.jl
+++ b/test/test_Quaternion.jl
@@ -70,11 +70,13 @@ for _ in 1:100
     let # test specialfunctions
         c = Complex(randn(2)...)
         q, q2 = sample(Quaternion{Float64}, 4)
-        unary_funs = [exp, log, sin, cos, sqrt, inv, conj, abs2, norm]
+        unary_funs = [identity, exp, log, sin, cos, sqrt, inv, conj, abs2, norm]
         # since every quaternion is conjugate to a complex number,
         # one can establish correctness as follows:
         for fun in unary_funs
             @test fun(Quaternion(c)) ≈ Quaternion(fun(c))
+            @test c * q ≈ Quaternion(c) * q
+            @test q2 * c ≈ q2 * Quaternion(c)
             @test q2 * fun(q) * inv(q2) ≈ fun(q2 * q * inv(q2))
         end
 


### PR DESCRIPTION
Not sure if this addresses #29, but at least it allows the `Base` promotion to work. This method was previously not tested, and probably not working.