### PR TITLE
Add missing Base.imag import

### DIFF
--- a/src/Quaternions.jl
+++ b/src/Quaternions.jl
@@ -3,7 +3,7 @@ __precompile__()
 module Quaternions
 
   import Base: +, -, *, /, ^
-  import Base: abs, abs2, angle, conj, cos, exp, inv, isfinite, log, real, sin, sqrt
+  import Base: abs, abs2, angle, conj, cos, exp, inv, isfinite, log, real, imag, sin, sqrt
   import Base: convert, promote_rule, float
   import LinearAlgebra: norm, normalize
 

--- a/test/test_Quaternion.jl
+++ b/test/test_Quaternion.jl
@@ -2,6 +2,12 @@
 using Quaternions: argq
 using LinearAlgebra
 
+let # test accessors
+    c = rand(4)
+    @test c[1] == real(quat(c...))
+    @test c[2:4] == imag(quat(c...))
+end
+
 # creating random examples
 sample(QT::Type{Quaternion{T}}) where {T <: Integer} = QT(rand(-100:100, 4)..., false)
 sample(QT::Type{Quaternion{T}}) where {T <: AbstractFloat} = QT(rand(Bool) ? quatrand() : nquatrand())


### PR DESCRIPTION
This adds a missing Base import for `imag()` which also affects promotions from complex numbers.