### PR TITLE
improve promotion and equality checking

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Quaternions"
 uuid = "94ee1d12-ae83-5a48-8b1c-48b8ff168ae0"
-version = "0.4.1"
+version = "0.4.2"
 
 [deps]
 DualNumbers = "fa6b7ba4-c1ee-5f82-b5fc-ecf0adba8f74"

--- a/src/DualQuaternion.jl
+++ b/src/DualQuaternion.jl
@@ -18,7 +18,7 @@ DualQuaternion(d1::Dual, d2::Dual, d3::Dual, d4::Dual, n::Bool) =
 
 DualQuaternion(x::Real) = DualQuaternion(Quaternion(x), Quaternion(zero(x)), abs(x) == one(x))
 
-DualQuaternion(d::Dual) = DualQuaternion(d, zero(d), zero(d), zero(d), abs(d) == one(DualNumbers.value(d)))
+DualQuaternion(d::Dual) = DualQuaternion(Quaternion(DualNumbers.value(d)), Quaternion(DualNumbers.epsilon(d)), (DualNumbers.value(d)==one(DualNumbers.value(d))) & iszero(DualNumbers.epsilon(d)))
 
 DualQuaternion(q::Quaternion) = DualQuaternion(q, zero(q), q.norm)
 

--- a/src/DualQuaternion.jl
+++ b/src/DualQuaternion.jl
@@ -21,14 +21,11 @@ DualQuaternion(q::Quaternion) = DualQuaternion(q, zero(q), q.norm)
 
 DualQuaternion(a::Vector) = DualQuaternion(zero(Quaternion{typeof(a[1])}), Quaternion(a))
 
-convert(::Type{DualQuaternion{T}}, x::Real) where {T} =
-    DualQuaternion(convert(Quaternion{T}, x), convert(Quaternion{T}, 0))
+convert(::Type{DualQuaternion{T}}, x::Real) where {T} = DualQuaternion(convert(T, x))
 
-convert(::Type{DualQuaternion{T}}, d::Dual) where {T} =
-    DualQuaternion(convert(Dual{T}, d), convert(Dual{T}, 0), convert(Dual{T}, 0), convert(Dual{T}, 0))
+convert(::Type{DualQuaternion{T}}, d::Dual) where {T} = DualQuaternion(convert(Dual{T}, d))
 
-convert(::Type{DualQuaternion{T}}, q::Quaternion) where {T} =
-    DualQuaternion(convert(Quaternion{T}, q), convert(Quaternion{T}, 0), q.norm)
+convert(::Type{DualQuaternion{T}}, q::Quaternion) where {T} = DualQuaternion(convert(Quaternion{T}, q))
 
 convert(::Type{DualQuaternion{T}}, q::DualQuaternion{T}) where {T <: Real} = q
 
@@ -112,6 +109,7 @@ end
                                                               dq.q0 * dw.qe + dq.qe * dw.q0,
                                                               dq.norm && dw.norm)
 (/)(dq::DualQuaternion, dw::DualQuaternion) = dq * inv(dw)
+(==)(q::DualQuaternion, w::DualQuaternion) = (q.q0 == w.q0) & (q.qe == w.qe) # ignore .norm field
 
 function angleaxis(dq::DualQuaternion)
   tq = dq.qe * conj(dq.q0)

--- a/src/DualQuaternion.jl
+++ b/src/DualQuaternion.jl
@@ -6,16 +6,19 @@ struct DualQuaternion{T<:Real} <: Number
   norm::Bool
 end
 
-DualQuaternion(q0::Quaternion, qe::Quaternion, n::Bool = false) =
+DualQuaternion(q0::Quaternion, qe::Quaternion, n::Bool = q0.norm) =
   DualQuaternion(promote(q0, qe)..., n)
 
-DualQuaternion(d1::Dual, d2::Dual, d3::Dual, d4::Dual, n::Bool = false) =
-  DualQuaternion(Quaternion(d1.re, d2.re, d3.re, d4.re, n),
-                  Quaternion(d1.du, d2.du, d3.du, d4.du), n)
+DualQuaternion(d1::Dual, d2::Dual, d3::Dual, d4::Dual) =
+  DualQuaternion(Quaternion(DualNumbers.value(d1), DualNumbers.value(d2), DualNumbers.value(d3), DualNumbers.value(d4)),
+                  Quaternion(DualNumbers.epsilon(d1), DualNumbers.epsilon(d2), DualNumbers.epsilon(d3), DualNumbers.epsilon(d4)))
+DualQuaternion(d1::Dual, d2::Dual, d3::Dual, d4::Dual, n::Bool) =
+  DualQuaternion(Quaternion(DualNumbers.value(d1), DualNumbers.value(d2), DualNumbers.value(d3), DualNumbers.value(d4), n),
+                  Quaternion(DualNumbers.epsilon(d1), DualNumbers.epsilon(d2), DualNumbers.epsilon(d3), DualNumbers.epsilon(d4)), n)
 
 DualQuaternion(x::Real) = DualQuaternion(Quaternion(x), Quaternion(zero(x)), abs(x) == one(x))
 
-DualQuaternion(d::Dual) = DualQuaternion(d, zero(d), zero(d), zero(d), abs(d) == one(d.re))
+DualQuaternion(d::Dual) = DualQuaternion(d, zero(d), zero(d), zero(d), abs(d) == one(d))
 
 DualQuaternion(q::Quaternion) = DualQuaternion(q, zero(q), q.norm)
 

--- a/src/DualQuaternion.jl
+++ b/src/DualQuaternion.jl
@@ -38,9 +38,7 @@ promote_rule(::Type{DualQuaternion{T}}, ::Type{S}) where {T <: Real, S <: Real} 
 promote_rule(::Type{Quaternion{T}}, ::Type{DualQuaternion{S}}) where {T <: Real, S <: Real} = DualQuaternion{promote_type(T, S)}
 promote_rule(::Type{DualQuaternion{T}}, ::Type{DualQuaternion{S}}) where {T <: Real, S <: Real} = DualQuaternion{promote_type(T, S)}
 
-dualquat(q1, q2, n=false) = DualQuaternion(q1, q2, n)
-dualquat(d1, d2, d3, d4, n=false) = DualQuaternion(d1, d2, d3, d4, n)
-dualquat(x) = DualQuaternion(x)
+const dualquat = DualQuaternion
 
 function show(io::IO, dq::DualQuaternion)
   show(io, dq.q0)

--- a/src/DualQuaternion.jl
+++ b/src/DualQuaternion.jl
@@ -18,7 +18,7 @@ DualQuaternion(d1::Dual, d2::Dual, d3::Dual, d4::Dual, n::Bool) =
 
 DualQuaternion(x::Real) = DualQuaternion(Quaternion(x), Quaternion(zero(x)), abs(x) == one(x))
 
-DualQuaternion(d::Dual) = DualQuaternion(d, zero(d), zero(d), zero(d), abs(d) == one(d))
+DualQuaternion(d::Dual) = DualQuaternion(d, zero(d), zero(d), zero(d), abs(d) == one(DualNumbers.value(d)))
 
 DualQuaternion(q::Quaternion) = DualQuaternion(q, zero(q), q.norm)
 

--- a/src/DualQuaternion.jl
+++ b/src/DualQuaternion.jl
@@ -41,8 +41,10 @@ promote_rule(::Type{DualQuaternion{T}}, ::Type{S}) where {T <: Real, S <: Real} 
 promote_rule(::Type{Quaternion{T}}, ::Type{DualQuaternion{S}}) where {T <: Real, S <: Real} = DualQuaternion{promote_type(T, S)}
 promote_rule(::Type{DualQuaternion{T}}, ::Type{DualQuaternion{S}}) where {T <: Real, S <: Real} = DualQuaternion{promote_type(T, S)}
 
-dualquat(q1, q2, n=false) = DualQuaternion(q1, q2, n)
-dualquat(d1, d2, d3, d4, n=false) = DualQuaternion(d1, d2, d3, d4, n)
+dualquat(q1, q2) = DualQuaternion(q1, q2)
+dualquat(q1, q2, n) = DualQuaternion(q1, q2, n)
+dualquat(d1, d2, d3, d4) = DualQuaternion(d1, d2, d3, d4)
+dualquat(d1, d2, d3, d4, n) = DualQuaternion(d1, d2, d3, d4, n)
 dualquat(x) = DualQuaternion(x)
 
 function show(io::IO, dq::DualQuaternion)

--- a/src/DualQuaternion.jl
+++ b/src/DualQuaternion.jl
@@ -6,7 +6,7 @@ struct DualQuaternion{T<:Real} <: Number
   norm::Bool
 end
 
-DualQuaternion(q0::Quaternion, qe::Quaternion, n::Bool = q0.norm) =
+DualQuaternion(q0::Quaternion, qe::Quaternion, n::Bool = false) =
   DualQuaternion(promote(q0, qe)..., n)
 
 DualQuaternion(d1::Dual, d2::Dual, d3::Dual, d4::Dual) =

--- a/src/DualQuaternion.jl
+++ b/src/DualQuaternion.jl
@@ -41,7 +41,9 @@ promote_rule(::Type{DualQuaternion{T}}, ::Type{S}) where {T <: Real, S <: Real} 
 promote_rule(::Type{Quaternion{T}}, ::Type{DualQuaternion{S}}) where {T <: Real, S <: Real} = DualQuaternion{promote_type(T, S)}
 promote_rule(::Type{DualQuaternion{T}}, ::Type{DualQuaternion{S}}) where {T <: Real, S <: Real} = DualQuaternion{promote_type(T, S)}
 
-const dualquat = DualQuaternion
+dualquat(q1, q2, n=false) = DualQuaternion(q1, q2, n)
+dualquat(d1, d2, d3, d4, n=false) = DualQuaternion(d1, d2, d3, d4, n)
+dualquat(x) = DualQuaternion(x)
 
 function show(io::IO, dq::DualQuaternion)
   show(io, dq.q0)

--- a/src/Octonion.jl
+++ b/src/Octonion.jl
@@ -32,7 +32,8 @@ promote_rule(::Type{Complex{T}}, ::Type{Octonion{S}}) where {T <: Real, S <: Rea
 promote_rule(::Type{Quaternion{T}}, ::Type{Octonion{S}}) where {T <: Real, S <: Real} = Octonion{promote_type(T, S)}
 promote_rule(::Type{Octonion{T}}, ::Type{Octonion{S}}) where {T <: Real, S <: Real} = Octonion{promote_type(T, S)}
 
-octo(p, v1, v2, v3, v4, v5, v6, v7, n = false) = Octonion(p, v1, v2, v3, v4, v5, v6, v7, n)
+octo(p, v1, v2, v3, v4, v5, v6, v7) = Octonion(p, v1, v2, v3, v4, v5, v6, v7)
+octo(p, v1, v2, v3, v4, v5, v6, v7, n) = Octonion(p, v1, v2, v3, v4, v5, v6, v7, n)
 octo(x) = Octonion(x)
 octo(s, a) = Octonion(s, a)
 

--- a/src/Octonion.jl
+++ b/src/Octonion.jl
@@ -32,7 +32,9 @@ promote_rule(::Type{Complex{T}}, ::Type{Octonion{S}}) where {T <: Real, S <: Rea
 promote_rule(::Type{Quaternion{T}}, ::Type{Octonion{S}}) where {T <: Real, S <: Real} = Octonion{promote_type(T, S)}
 promote_rule(::Type{Octonion{T}}, ::Type{Octonion{S}}) where {T <: Real, S <: Real} = Octonion{promote_type(T, S)}
 
-const octo = Octonion
+octo(p, v1, v2, v3, v4, v5, v6, v7, n = false) = Octonion(p, v1, v2, v3, v4, v5, v6, v7, n)
+octo(x) = Octonion(x)
+octo(s, a) = Octonion(s, a)
 
 function show(io::IO, o::Octonion)
   pm(x) = x < 0 ? " - $(-x)" : " + $x"

--- a/src/Octonion.jl
+++ b/src/Octonion.jl
@@ -110,7 +110,7 @@ end
 
 (/)(o::Octonion, w::Octonion) = o * inv(w)
 
-(==)(q::Octonion, w::Octonion) = (q.s == w.s)   & (q.v1 == w.v1) & (q.v2 == w.v2) & (q.v3 == w.v3) &
+(==)(q::Octonion, w::Octonion) = (q.s == w.s) & (q.v1 == w.v1) & (q.v2 == w.v2) & (q.v3 == w.v3) &
                                  (q.v4 == w.v4) & (q.v5 == w.v5) & (q.v6 == w.v6) & (q.v7 == w.v7) # ignore .norm field
 
 function exp(o::Octonion)

--- a/src/Octonion.jl
+++ b/src/Octonion.jl
@@ -18,12 +18,9 @@ Octonion(q::Quaternion) = Octonion(q.s, q.v1, q.v2, q.v3, zero(q.s), zero(q.s), 
 Octonion(s::Real, a::Vector) = Octonion(s, a[1], a[2], a[3], a[4], a[5], a[6], a[7])
 Octonion(a::Vector) = Octonion(0, a[1], a[2], a[3], a[4], a[5], a[6], a[7])
 
-convert(::Type{Octonion{T}}, x::Real) where {T} =
-  Octonion(convert(T, x), convert(T, 0), convert(T, 0), convert(T, 0), convert(T, 0), convert(T, 0), convert(T, 0), convert(T, 0))
-convert(::Type{Octonion{T}}, z::Complex) where {T} =
-  Octonion(convert(T, real(z)), convert(T, imag(z)), convert(T, 0), convert(T, 0), convert(T, 0), convert(T, 0), convert(T, 0), convert(T, 0))
-convert(::Type{Octonion{T}}, q::Quaternion) where {T} =
-  Octonion(convert(T, real(q)), convert(T, q.v1), convert(T, q.v2), convert(T, q.v3), convert(T, 0), convert(T, 0), convert(T, 0), convert(T, 0))
+convert(::Type{Octonion{T}}, x::Real) where {T} = Octonion(convert(T, x))
+convert(::Type{Octonion{T}}, z::Complex) where {T} = Octonion(convert(Complex{T}, z))
+convert(::Type{Octonion{T}}, q::Quaternion) where {T} = Octonion(convert(Quaternion{T}, q))
 convert(::Type{Octonion{T}}, o::Octonion{T}) where {T <: Real} = o
 convert(::Type{Octonion{T}}, o::Octonion) where {T} =
   Octonion(convert(T, o.s), convert(T, o.v1), convert(T, o.v2), convert(T, o.v3), convert(T, o.v4), convert(T, o.v5), convert(T, o.v6), convert(T, o.v7), o.norm)
@@ -112,6 +109,9 @@ end
           )
 
 (/)(o::Octonion, w::Octonion) = o * inv(w)
+
+(==)(q::Octonion, w::Octonion) = (q.s == w.s)   & (q.v1 == w.v1) & (q.v2 == w.v2) & (q.v3 == w.v3) &
+                                 (q.v4 == w.v4) & (q.v5 == w.v5) & (q.v6 == w.v6) & (q.v7 == w.v7) # ignore .norm field
 
 function exp(o::Octonion)
   s = o.s

--- a/src/Octonion.jl
+++ b/src/Octonion.jl
@@ -32,9 +32,7 @@ promote_rule(::Type{Complex{T}}, ::Type{Octonion{S}}) where {T <: Real, S <: Rea
 promote_rule(::Type{Quaternion{T}}, ::Type{Octonion{S}}) where {T <: Real, S <: Real} = Octonion{promote_type(T, S)}
 promote_rule(::Type{Octonion{T}}, ::Type{Octonion{S}}) where {T <: Real, S <: Real} = Octonion{promote_type(T, S)}
 
-octo(p, v1, v2, v3, v4, v5, v6, v7, n = false) = Octonion(p, v1, v2, v3, v4, v5, v6, v7, n)
-octo(x) = Octonion(x)
-octo(s, a) = Octonion(s, a)
+const octo = Octonion
 
 function show(io::IO, o::Octonion)
   pm(x) = x < 0 ? " - $(-x)" : " + $x"

--- a/src/Quaternion.jl
+++ b/src/Quaternion.jl
@@ -16,8 +16,8 @@ Quaternion(z::Complex) = Quaternion(z.re, z.im, zero(z.re), zero(z.re), abs(z) =
 Quaternion(s::Real, a::Vector) = Quaternion(s, a[1], a[2], a[3])
 Quaternion(a::Vector) = Quaternion(0, a[1], a[2], a[3])
 
-convert(::Type{Quaternion{T}}, x::Real) where {T} = Quaternion(convert(T,x))
-convert(::Type{Quaternion{T}}, z::Complex) where {T} = Quaternion(convert(Complex{T},z))
+convert(::Type{Quaternion{T}}, x::Real) where {T} = Quaternion(convert(T, x))
+convert(::Type{Quaternion{T}}, z::Complex) where {T} = Quaternion(convert(Complex{T}, z))
 convert(::Type{Quaternion{T}}, q::Quaternion{T}) where {T <: Real} = q
 convert(::Type{Quaternion{T}}, q::Quaternion) where {T} =
     Quaternion(convert(T, q.s), convert(T, q.v1), convert(T, q.v2), convert(T, q.v3), q.norm)
@@ -94,7 +94,7 @@ end
                                                q.norm && w.norm)
 (/)(q::Quaternion, w::Quaternion) = q * inv(w)
 
-(==)(q::Quaternion{T}, w::Quaternion{T}) where T = (q.s == w.s && q.v1 == w.v1 && q.v2 == w.v2 && q.v3 == w.v3) # ignore .norm field
+(==)(q::Quaternion, w::Quaternion) = (q.s == w.s && q.v1 == w.v1 && q.v2 == w.v2 && q.v3 == w.v3) # ignore .norm field
 
 angleaxis(q::Quaternion) = angle(q), axis(q)
 

--- a/src/Quaternion.jl
+++ b/src/Quaternion.jl
@@ -28,9 +28,7 @@ promote_rule(::Type{Quaternion{T}}, ::Type{S}) where {T <: Real, S <: Real} = Qu
 promote_rule(::Type{Complex{T}}, ::Type{Quaternion{S}}) where {T <: Real, S <: Real} = Quaternion{promote_type(T, S)}
 promote_rule(::Type{Quaternion{T}}, ::Type{Quaternion{S}}) where {T <: Real, S <: Real} = Quaternion{promote_type(T, S)}
 
-quat(p, v1, v2, v3, n = false) = Quaternion(p, v1, v2, v3, n)
-quat(x) = Quaternion(x)
-quat(s, a) = Quaternion(s, a)
+const quat = Quaternion
 
 function show(io::IO, q::Quaternion)
     pm(x) = x < 0 ? " - $(-x)" : " + $x"

--- a/src/Quaternion.jl
+++ b/src/Quaternion.jl
@@ -94,7 +94,7 @@ end
                                                q.norm && w.norm)
 (/)(q::Quaternion, w::Quaternion) = q * inv(w)
 
-(==)(q::Quaternion, w::Quaternion) = (q.s == w.s && q.v1 == w.v1 && q.v2 == w.v2 && q.v3 == w.v3) # ignore .norm field
+(==)(q::Quaternion, w::Quaternion) = (q.s == w.s) & (q.v1 == w.v1) & (q.v2 == w.v2) & (q.v3 == w.v3) # ignore .norm field
 
 angleaxis(q::Quaternion) = angle(q), axis(q)
 

--- a/src/Quaternion.jl
+++ b/src/Quaternion.jl
@@ -28,7 +28,8 @@ promote_rule(::Type{Quaternion{T}}, ::Type{S}) where {T <: Real, S <: Real} = Qu
 promote_rule(::Type{Complex{T}}, ::Type{Quaternion{S}}) where {T <: Real, S <: Real} = Quaternion{promote_type(T, S)}
 promote_rule(::Type{Quaternion{T}}, ::Type{Quaternion{S}}) where {T <: Real, S <: Real} = Quaternion{promote_type(T, S)}
 
-quat(p, v1, v2, v3, n = false) = Quaternion(p, v1, v2, v3, n)
+quat(p, v1, v2, v3) = Quaternion(p, v1, v2, v3)
+quat(p, v1, v2, v3, n) = Quaternion(p, v1, v2, v3, n)
 quat(x) = Quaternion(x)
 quat(s, a) = Quaternion(s, a)
 

--- a/src/Quaternion.jl
+++ b/src/Quaternion.jl
@@ -28,7 +28,9 @@ promote_rule(::Type{Quaternion{T}}, ::Type{S}) where {T <: Real, S <: Real} = Qu
 promote_rule(::Type{Complex{T}}, ::Type{Quaternion{S}}) where {T <: Real, S <: Real} = Quaternion{promote_type(T, S)}
 promote_rule(::Type{Quaternion{T}}, ::Type{Quaternion{S}}) where {T <: Real, S <: Real} = Quaternion{promote_type(T, S)}
 
-const quat = Quaternion
+quat(p, v1, v2, v3, n = false) = Quaternion(p, v1, v2, v3, n)
+quat(x) = Quaternion(x)
+quat(s, a) = Quaternion(s, a)
 
 function show(io::IO, q::Quaternion)
     pm(x) = x < 0 ? " - $(-x)" : " + $x"

--- a/src/Quaternion.jl
+++ b/src/Quaternion.jl
@@ -16,10 +16,8 @@ Quaternion(z::Complex) = Quaternion(z.re, z.im, zero(z.re), zero(z.re), abs(z) =
 Quaternion(s::Real, a::Vector) = Quaternion(s, a[1], a[2], a[3])
 Quaternion(a::Vector) = Quaternion(0, a[1], a[2], a[3])
 
-convert(::Type{Quaternion{T}}, x::Real) where {T} =
-    Quaternion(convert(T, x), convert(T, 0), convert(T, 0), convert(T, 0))
-convert(::Type{Quaternion{T}}, z::Complex) where {T} =
-    Quaternion(convert(T, real(z)), convert(T, imag(z)), convert(T, 0), convert(T, 0))
+convert(::Type{Quaternion{T}}, x::Real) where {T} = Quaternion(convert(T,x))
+convert(::Type{Quaternion{T}}, z::Complex) where {T} = Quaternion(convert(Complex{T},z))
 convert(::Type{Quaternion{T}}, q::Quaternion{T}) where {T <: Real} = q
 convert(::Type{Quaternion{T}}, q::Quaternion) where {T} =
     Quaternion(convert(T, q.s), convert(T, q.v1), convert(T, q.v2), convert(T, q.v3), q.norm)
@@ -95,6 +93,8 @@ end
                                                q.s * w.v3 + q.v1 * w.v2 - q.v2 * w.v1 + q.v3 * w.s,
                                                q.norm && w.norm)
 (/)(q::Quaternion, w::Quaternion) = q * inv(w)
+
+(==)(q::Quaternion{T}, w::Quaternion{T}) where T = (q.s == w.s && q.v1 == w.v1 && q.v2 == w.v2 && q.v3 == w.v3) # ignore .norm field
 
 angleaxis(q::Quaternion) = angle(q), axis(q)
 

--- a/src/Quaternion.jl
+++ b/src/Quaternion.jl
@@ -6,7 +6,7 @@ struct Quaternion{T<:Real} <: Number
     norm::Bool
 end
 
-(::Type{Quaternion{T}})(x::Real) where {T} = Quaternion{T}(x, 0, 0, 0, false)
+(::Type{Quaternion{T}})(x::Real) where {T<:Real} = Quaternion(convert(T, x))
 (::Type{Quaternion{T}})(q::Quaternion{T}) where {T<:Real} = q
 (::Type{Quaternion{T}})(q::Quaternion) where {T<:Real} = Quaternion{T}(q.s, q.v1, q.v2, q.v3, q.norm)
 Quaternion(s::Real, v1::Real, v2::Real, v3::Real, n::Bool = false) =

--- a/src/Quaternions.jl
+++ b/src/Quaternions.jl
@@ -2,7 +2,7 @@ __precompile__()
 
 module Quaternions
 
-  import Base: +, -, *, /, ^
+  import Base: +, -, *, /, ^, ==
   import Base: abs, abs2, angle, conj, cos, exp, inv, isfinite, log, real, sin, sqrt
   import Base: convert, promote_rule, float
   import LinearAlgebra: norm, normalize

--- a/test/test_Quaternion.jl
+++ b/test/test_Quaternion.jl
@@ -28,9 +28,10 @@ end
 
 @testset "promotions and equalities" begin
     @test Quaternion(1,0,0,0,false) == Quaternion(1,0,0,0,true) # test that .norm field does not affect equality
-    @test Quaternion(1) == 1 # test promotion
+    @test Quaternion(1) == 1.0 # test promotion
     @test Quaternion(1,2,0,0) == Complex(1.0,2.0) # test promotion
     @test Quaternion{Float64}(1) === Quaternion(1.0) # explicit type construction
+    @test quat(1) === Quaternion(1) # checking the .norm field in particular
     @test quat(1,0,0,0) === Quaternion(1,0,0,0) # checking the .norm field in particular
     @test quat(1,2,3,4) === Quaternion(1,2,3,4)
     @test quat(Quaternion(1,0,0,0)) === Quaternion(1,0,0,0) # checking the .norm field in particular
@@ -40,13 +41,14 @@ end
 
     @test Quaternion(1,2,3,4) == DualQuaternion(Quaternion(1,2,3,4))
     @test Quaternion(1,2,3,4) != DualQuaternion(Quaternion(1,2,3,4),Quaternion(5,6,7,8))
-    @test DualQuaternion(1) == 1
+    @test DualQuaternion(1) == 1.0 # test promotion
     @test DualQuaternion(Quaternion(1,2,3,4),Quaternion(5,6,7,8)) == DualQuaternion(Quaternion(1.0,2,3,4),Quaternion(5,6,7,8))
     @test DualQuaternion(Quaternion(1,2,3,4),Quaternion(5,6,7,8)) != DualQuaternion(Quaternion(1.0,2,3,4),Quaternion(1,2,3,4))
     @test dualquat(Quaternion(1,0,0,0)) == Quaternion(1,0,0,0)
     @test dualquat(Quaternion(1,2,3,4)) == Quaternion(1,2,3,4)
     @test dualquat(Quaternion(1,0,0,0)) === DualQuaternion(Quaternion(1,0,0,0)) # checking the .norm field in particular
     @test dualquat(Quaternion(1,2,3,4)) === DualQuaternion(Quaternion(1,2,3,4))
+    @test dualquat(1) === DualQuaternion(1)
     @test dualquat(Dual(1,2)) === DualQuaternion(Dual(1,2))
     @test dualquat(Dual(1,2),Dual(0),Dual(0),Dual(0)) === DualQuaternion(Dual(1,2),Dual(0),Dual(0),Dual(0))
     @test dualquat(Quaternion(1,0,0,0),Quaternion(0),false).norm == false # respect the .norm input (even if wrong)
@@ -57,10 +59,11 @@ end
     @test Quaternion(1,2,3,4) == Octonion(1,2,3,4,0,0,0,0)
     @test Quaternion(1,2,3,4) != Octonion(1,2,3,4,5,6,7,8)
     @test Octonion(1,0,0,0,0,0,0,0,false) == Octonion(1,0,0,0,0,0,0,0,true) # test that .norm field does not affect equality
-    @test Octonion(1) == 1.0
+    @test Octonion(1) == 1.0 # test promotion
     @test Octonion(Complex(1,2)) == Complex(1,2)
     @test Octonion(1.0,2,3,4,5,6,7,8) == Octonion(1,2,3,4,5,6,7,8)
     @test Octonion(1.0,2,3,4,5,6,7,8) != Octonion(1,2,3,4,1,2,3,4)
+    @test octo(1) === Octonion(1) # checking the .norm field in particular
     @test octo(1,0,0,0,0,0,0,0) === Octonion(1,0,0,0,0,0,0,0) # checking the .norm field in particular
     @test octo(1,2,3,4,5,6,7,8) === Octonion(1,2,3,4,5,6,7,8)
     @test octo(Octonion(1,0,0,0,0,0,0,0)) === Octonion(1,0,0,0,0,0,0,0) # checking the .norm field in particular

--- a/test/test_Quaternion.jl
+++ b/test/test_Quaternion.jl
@@ -1,5 +1,6 @@
 
 using Quaternions: argq
+import DualNumbers
 using LinearAlgebra
 
 # creating random examples
@@ -26,24 +27,41 @@ end
 
 @testset "promotions and equalities" begin
     @test Quaternion(1,0,0,0,false) == Quaternion(1,0,0,0,true) # test that .norm field does not affect equality
-    @test Quaternion(1) == 1.0 # test promotion
+    @test Quaternion(1) == 1 # test promotion
     @test Quaternion(1,2,0,0) == Complex(1.0,2.0) # test promotion
 
-    @test Quaternion(1.0,2,3,4) == DualQuaternion(Quaternion(1,2,3,4))
-    @test Quaternion(1.0,2,3,4) != DualQuaternion(Quaternion(1,2,3,4),Quaternion(5,6,7,8))
-    @test DualQuaternion(1) == 1.0
+    @test Quaternion(1,2,3,4) == DualQuaternion(Quaternion(1,2,3,4))
+    @test Quaternion(1,2,3,4) != DualQuaternion(Quaternion(1,2,3,4),Quaternion(5,6,7,8))
+    @test DualQuaternion(1) == 1
     @test DualQuaternion(Quaternion(1,2,3,4),Quaternion(5,6,7,8)) == DualQuaternion(Quaternion(1.0,2,3,4),Quaternion(5,6,7,8))
     @test DualQuaternion(Quaternion(1,2,3,4),Quaternion(5,6,7,8)) != DualQuaternion(Quaternion(1.0,2,3,4),Quaternion(1,2,3,4))
 
-    @test Quaternion(1.0,2,3,4) == Octonion(1,2,3,4,0,0,0,0)
-    @test Quaternion(1.0,2,3,4) != Octonion(1,2,3,4,5,6,7,8)
+    @test Quaternion(1,2,3,4) == Octonion(1,2,3,4,0,0,0,0)
+    @test Quaternion(1,2,3,4) != Octonion(1,2,3,4,5,6,7,8)
     @test Octonion(1,0,0,0,0,0,0,0,false) == Octonion(1,0,0,0,0,0,0,0,true) # test that .norm field does not affect equality
     @test Octonion(1) == 1.0
+    @test Octonion(Complex(1,2)) == Complex(1,2)
     @test Octonion(1.0,2,3,4,5,6,7,8) == Octonion(1,2,3,4,5,6,7,8)
     @test Octonion(1.0,2,3,4,5,6,7,8) != Octonion(1,2,3,4,1,2,3,4)
 end
 
-let # test rotations
+@testset "conversions" begin
+    @test convert(Quaternion{Float64},1) === Quaternion(1.0)
+    @test convert(Quaternion{Float64},Complex(1,2)) === Quaternion(1.0,2.0,0.0,0.0)
+    @test convert(Quaternion{Float64},Quaternion(1,2,3,4)) === Quaternion(1.0,2.0,3.0,4.0)
+
+    @test convert(DualQuaternion{Float64},1) === DualQuaternion(1.0)
+    @test convert(DualQuaternion{Float64},DualNumbers.Dual(1,2)) === DualQuaternion(Quaternion(1.0),Quaternion(2.0))
+    @test convert(DualQuaternion{Float64},Quaternion(1,2,3,4)) === DualQuaternion(Quaternion(1.0,2.0,3.0,4.0))
+    @test convert(DualQuaternion{Float64},DualQuaternion(Quaternion(1,2,3,4),Quaternion(5,6,7,8))) === DualQuaternion(Quaternion(1.0,2.0,3.0,4.0),Quaternion(5.0,6.0,7.0,8.0))
+
+    @test convert(Octonion{Float64},1) === Octonion(1.0)
+    @test convert(Octonion{Float64},Complex(1,2)) === Octonion(1.0,2.0,0.0,0.0,0.0,0.0,0.0,0.0)
+    @test convert(Octonion{Float64},Quaternion(1,2,3,4)) === Octonion(1.0,2.0,3.0,4.0,0.0,0.0,0.0,0.0)
+    @test convert(Octonion{Float64},Octonion(1,2,3,4,5,6,7,8)) === Octonion(1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0)
+end
+
+@testset "rotations" begin # test rotations
     qx = qrotation([1, 0, 0], pi / 4)
     @test qx * qx ≈ qrotation([1, 0, 0], pi / 2)
     @test qx^2 ≈ qrotation([1, 0, 0], pi / 2)

--- a/test/test_Quaternion.jl
+++ b/test/test_Quaternion.jl
@@ -63,6 +63,8 @@ end
     @test dualquat(1) === DualQuaternion(1)
     @test dualquat(Dual(1,2)) === DualQuaternion(Dual(1,2))
     @test dualquat(Dual(1,2),Dual(0),Dual(0),Dual(0)) === DualQuaternion(Dual(1,2),Dual(0),Dual(0),Dual(0))
+    @test dualquat(Quaternion(1,2,3,4),Quaternion(5,6,7,8)) == DualQuaternion(Quaternion(1,2,3,4),Quaternion(5,6,7,8))
+    @test dualquat(Quaternion(1,0,0,0),Quaternion(0)).norm == false
     @test dualquat(Quaternion(1,0,0,0),Quaternion(0),false).norm == false # respect the .norm input (even if wrong)
     @test dualquat(Quaternion(1,2,3,4),Quaternion(0),true).norm == true # respect the .norm input (even if wrong)
     @test dualquat(Dual(2,0),Dual(0),Dual(0),Dual(0),true).norm == true # respect the .norm input (even if wrong)

--- a/test/test_Quaternion.jl
+++ b/test/test_Quaternion.jl
@@ -28,6 +28,19 @@ let # test promotions and equalities
     @test Quaternion(1,0,0,0,false) == Quaternion(1,0,0,0,true) # test that .norm field does not affect equality
     @test Quaternion(1) == 1.0 # test promotion
     @test Quaternion(1,2,0,0) == Complex(1.0,2.0) # test promotion
+
+    @test Quaternion(1.0,2,3,4) == DualQuaternion(Quaternion(1,2,3,4))
+    @test Quaternion(1.0,2,3,4) != DualQuaternion(Quaternion(1,2,3,4),Quaternion(5,6,7,8))
+    @test DualQuaternion(1) == 1.0
+    @test DualQuaternion(Quaternion(1,2,3,4),Quaternion(5,6,7,8)) == DualQuaternion(Quaternion(1.0,2,3,4),Quaternion(5,6,7,8))
+    @test DualQuaternion(Quaternion(1,2,3,4),Quaternion(5,6,7,8)) != DualQuaternion(Quaternion(1.0,2,3,4),Quaternion(1,2,3,4))
+
+    @test Quaternion(1.0,2,3,4) == Octonion(1,2,3,4,0,0,0,0)
+    @test Quaternion(1.0,2,3,4) != Octonion(1,2,3,4,5,6,7,8)
+    @test Octonion(1,0,0,0,0,0,0,0,false) == Octonion(1,0,0,0,0,0,0,0,true) # test that .norm field does not affect equality
+    @test Octonion(1) == 1.0
+    @test Octonion(1.0,2,3,4,5,6,7,8) == Octonion(1,2,3,4,5,6,7,8)
+    @test Octonion(1.0,2,3,4,5,6,7,8) != Octonion(1,2,3,4,1,2,3,4)
 end
 
 let # test rotations

--- a/test/test_Quaternion.jl
+++ b/test/test_Quaternion.jl
@@ -1,6 +1,6 @@
 
 using Quaternions: argq
-import DualNumbers
+using DualNumbers
 using LinearAlgebra
 using Random
 

--- a/test/test_Quaternion.jl
+++ b/test/test_Quaternion.jl
@@ -98,15 +98,6 @@ end
     @test angle(qrotation([0, 1, 0], pi / 4)) ≈ pi / 4
     @test angle(qrotation([0, 0, 1], pi / 2)) ≈ pi / 2
 
-    # Regression test for
-    # https://github.com/JuliaGeometry/Quaternions.jl/issues/8#issuecomment-610640094
-    struct MyReal <: Real
-      val::Real
-    end
-    Base.:(/)(a::MyReal, b::Real) = a.val / b
-    # this used to throw an error
-    qrotation([1, 0, 0], MyReal(1.5))
-
     let # test numerical stability of angle
         ax = randn(3)
         for θ in [1e-9, π - 1e-9]
@@ -115,6 +106,15 @@ end
         end
     end
 end
+
+# Regression test for
+# https://github.com/JuliaGeometry/Quaternions.jl/issues/8#issuecomment-610640094
+struct MyReal <: Real
+    val::Real
+end
+Base.:(/)(a::MyReal, b::Real) = a.val / b
+# this used to throw an error
+@test qrotation([1, 0, 0], MyReal(1.5)) == qrotation([1, 0, 0], 1.5)
 
 for _ in 1:100
     let # test specialfunctions

--- a/test/test_Quaternion.jl
+++ b/test/test_Quaternion.jl
@@ -30,12 +30,29 @@ end
     @test Quaternion(1,0,0,0,false) == Quaternion(1,0,0,0,true) # test that .norm field does not affect equality
     @test Quaternion(1) == 1 # test promotion
     @test Quaternion(1,2,0,0) == Complex(1.0,2.0) # test promotion
+    @test Quaternion{Float64}(1) === Quaternion(1.0) # explicit type construction
+    @test quat(1,0,0,0) === Quaternion(1,0,0,0) # checking the .norm field in particular
+    @test quat(1,2,3,4) === Quaternion(1,2,3,4)
+    @test quat(Quaternion(1,0,0,0)) === Quaternion(1,0,0,0) # checking the .norm field in particular
+    @test quat(Quaternion(1,2,3,4)) === Quaternion(1,2,3,4)
+    @test quat(1,0,0,0,false).norm == false # respect the .norm input (even if wrong)
+    @test quat(1,2,3,4,true).norm == true # respect the .norm input (even if wrong)
 
     @test Quaternion(1,2,3,4) == DualQuaternion(Quaternion(1,2,3,4))
     @test Quaternion(1,2,3,4) != DualQuaternion(Quaternion(1,2,3,4),Quaternion(5,6,7,8))
     @test DualQuaternion(1) == 1
     @test DualQuaternion(Quaternion(1,2,3,4),Quaternion(5,6,7,8)) == DualQuaternion(Quaternion(1.0,2,3,4),Quaternion(5,6,7,8))
     @test DualQuaternion(Quaternion(1,2,3,4),Quaternion(5,6,7,8)) != DualQuaternion(Quaternion(1.0,2,3,4),Quaternion(1,2,3,4))
+    @test dualquat(Quaternion(1,0,0,0)) == Quaternion(1,0,0,0)
+    @test dualquat(Quaternion(1,2,3,4)) == Quaternion(1,2,3,4)
+    @test dualquat(Quaternion(1,0,0,0)) === DualQuaternion(Quaternion(1,0,0,0)) # checking the .norm field in particular
+    @test dualquat(Quaternion(1,2,3,4)) === DualQuaternion(Quaternion(1,2,3,4))
+    @test dualquat(Dual(1,2)) === DualQuaternion(Dual(1,2))
+    @test dualquat(Dual(1,2),Dual(0),Dual(0),Dual(0)) === DualQuaternion(Dual(1,2),Dual(0),Dual(0),Dual(0))
+    @test dualquat(Quaternion(1,0,0,0),Quaternion(0),false).norm == false # respect the .norm input (even if wrong)
+    @test dualquat(Quaternion(1,2,3,4),Quaternion(0),true).norm == true # respect the .norm input (even if wrong)
+    @test dualquat(Dual(2,0),Dual(0),Dual(0),Dual(0),true).norm == true # respect the .norm input (even if wrong)
+    @test dualquat(Dual(1,0),Dual(0),Dual(0),Dual(0),false).norm == false # respect the .norm input (even if wrong)
 
     @test Quaternion(1,2,3,4) == Octonion(1,2,3,4,0,0,0,0)
     @test Quaternion(1,2,3,4) != Octonion(1,2,3,4,5,6,7,8)
@@ -44,6 +61,12 @@ end
     @test Octonion(Complex(1,2)) == Complex(1,2)
     @test Octonion(1.0,2,3,4,5,6,7,8) == Octonion(1,2,3,4,5,6,7,8)
     @test Octonion(1.0,2,3,4,5,6,7,8) != Octonion(1,2,3,4,1,2,3,4)
+    @test octo(1,0,0,0,0,0,0,0) === Octonion(1,0,0,0,0,0,0,0) # checking the .norm field in particular
+    @test octo(1,2,3,4,5,6,7,8) === Octonion(1,2,3,4,5,6,7,8)
+    @test octo(Octonion(1,0,0,0,0,0,0,0)) === Octonion(1,0,0,0,0,0,0,0) # checking the .norm field in particular
+    @test octo(Octonion(1,2,3,4,5,6,7,8)) === Octonion(1,2,3,4,5,6,7,8)
+    @test octo(1,0,0,0,0,0,0,0,false).norm == false # respect the .norm input (even if wrong)
+    @test octo(1,2,3,4,5,6,7,8,true).norm == true # respect the .norm input (even if wrong)
 end
 
 @testset "conversions" begin

--- a/test/test_Quaternion.jl
+++ b/test/test_Quaternion.jl
@@ -24,6 +24,12 @@ for _ in 1:10, T in (Float32, Float64, Int32, Int64)
     test_multiplicative(c1, c2, +, Quaternion)
 end
 
+let # test promotions and equalities
+    @test Quaternion(1,0,0,0,false) == Quaternion(1,0,0,0,true) # test that .norm field does not affect equality
+    @test Quaternion(1) == 1.0 # test promotion
+    @test Quaternion(1,2,0,0) == Complex(1.0,2.0) # test promotion
+end
+
 let # test rotations
     qx = qrotation([1, 0, 0], pi / 4)
     @test qx * qx ≈ qrotation([1, 0, 0], pi / 2)

--- a/test/test_Quaternion.jl
+++ b/test/test_Quaternion.jl
@@ -24,7 +24,7 @@ for _ in 1:10, T in (Float32, Float64, Int32, Int64)
     test_multiplicative(c1, c2, +, Quaternion)
 end
 
-let # test promotions and equalities
+@testset "promotions and equalities" begin
     @test Quaternion(1,0,0,0,false) == Quaternion(1,0,0,0,true) # test that .norm field does not affect equality
     @test Quaternion(1) == 1.0 # test promotion
     @test Quaternion(1,2,0,0) == Complex(1.0,2.0) # test promotion


### PR DESCRIPTION
This PR is primarily motivated by an issue where `Quaternion(1) == 1` returned `false`. There were two issues at play here.

First, `convert(Quaternion,::Real)` and `convert(Quaternion,::Complex)` were never setting the `.norm` field of the resulting Quaternion. This meant that `Quaternion(1.0).norm == true` while `convert(Quaternion,1.0).norm == false`.

Second, there was no special-cased `==(::Quaternion,::Quaternion)` method. This meant that equality required the `.norm` fields to match.

This PR reroutes `convert` calls through the normal constructors to help `.norm` be set more consistently. It also adds a `==` method for Quaternions so that the `.norm` field is ignored in equality checks. Lastly, it adds some tests along these lines.