### PR TITLE
fix piracy and type instability

### DIFF
--- a/src/Quaternion.jl
+++ b/src/Quaternion.jl
@@ -209,11 +209,12 @@ function qrotation(axis::Vector{T}, theta) where {T <: Real}
     end
     normaxis = norm(axis)
     if iszero(normaxis)
-        error("must provide nonzero rotation axis")
+        normaxis = one(normaxis)
+        theta = zero(theta)
     end
     s,c = sincos(theta / 2)
-    scaleby = s / normaxis # normaxis not zero by earlier check
-    Quaternion(c * one(scaleby), scaleby * axis[1], scaleby * axis[2], scaleby * axis[3], true)
+    scaleby = s / normaxis
+    Quaternion(c, scaleby * axis[1], scaleby * axis[2], scaleby * axis[3], true)
 end
 
 # Variant of the above where norm(rotvec) encodes theta
@@ -224,7 +225,7 @@ function qrotation(rotvec::Vector{T}) where {T <: Real}
     theta = norm(rotvec)
     s,c = sincos(theta / 2)
     scaleby = s / (iszero(theta) ? one(theta) : theta)
-    return Quaternion(c, scaleby * rotvec[1], scaleby * rotvec[2], scaleby * rotvec[3], true)
+    Quaternion(c, scaleby * rotvec[1], scaleby * rotvec[2], scaleby * rotvec[3], true)
 end
 
 function qrotation(dcm::Matrix{T}) where {T<:Real}

--- a/src/Quaternion.jl
+++ b/src/Quaternion.jl
@@ -193,10 +193,13 @@ function qrotation(axis::Vector{T}, theta) where {T <: Real}
     if length(axis) != 3
         error("Must be a 3-vector")
     end
-    u = normalize(axis)
-    thetaT = convert(eltype(u), theta)
-    s = sin(thetaT / 2)
-    Quaternion(cos(thetaT / 2), s * u[1], s * u[2], s * u[3], true)
+    normaxis = norm(axis)
+    if iszero(normaxis)
+        error("must provide nonzero rotation axis")
+    end
+    s,c = sincos(oftype(normaxis, theta / 2))
+    scaleby = s / normaxis # normaxis not zero by earlier check
+    Quaternion(c, scaleby * axis[1], scaleby * axis[2], scaleby * axis[3], true)
 end
 
 # Variant of the above where norm(rotvec) encodes theta
@@ -205,11 +208,9 @@ function qrotation(rotvec::Vector{T}) where {T <: Real}
         error("Must be a 3-vector")
     end
     theta = norm(rotvec)
-    if theta > 0
-        s = sin(theta / 2) / theta  # divide by theta to make rotvec a unit vector
-        return Quaternion(cos(theta / 2), s * rotvec[1], s * rotvec[2], s * rotvec[3], true)
-    end
-    Quaternion(one(T), zero(T), zero(T), zero(T), true)
+    s,c = sincos(theta / 2)
+    scaleby = s / (iszero(theta) ? one(theta) : theta)
+    return Quaternion(c, scaleby * rotvec[1], scaleby * rotvec[2], scaleby * rotvec[3], true)
 end
 
 function qrotation(dcm::Matrix{T}) where {T<:Real}
@@ -248,14 +249,6 @@ function rotationmatrix_normalized(q::Quaternion)
     [1 - (yy + zz)     xy - sz     xz + sy;
         xy + sz   1 - (xx + zz)    yz - sx;
         xz - sy      yz + sx  1 - (xx + yy)]
-end
-
-function normalize(v::Vector{T}) where {T}
-    nv = norm(v)
-    if nv > 0
-        return v / nv
-    end
-    zeros(promote_type(T, typeof(nv)), length(v))
 end
 
 

--- a/src/Quaternion.jl
+++ b/src/Quaternion.jl
@@ -213,7 +213,7 @@ function qrotation(axis::Vector{T}, theta) where {T <: Real}
     end
     s,c = sincos(theta / 2)
     scaleby = s / normaxis # normaxis not zero by earlier check
-    Quaternion(c, scaleby * axis[1], scaleby * axis[2], scaleby * axis[3], true)
+    Quaternion(c * one(scaleby), scaleby * axis[1], scaleby * axis[2], scaleby * axis[3], true)
 end
 
 # Variant of the above where norm(rotvec) encodes theta

--- a/src/Quaternion.jl
+++ b/src/Quaternion.jl
@@ -209,7 +209,7 @@ function qrotation(axis::Vector{T}, theta) where {T <: Real}
     end
     normaxis = norm(axis)
     if iszero(normaxis)
-        normaxis = one(normaxis)
+        normaxis = oneunit(normaxis)
         theta = zero(theta)
     end
     s,c = sincos(theta / 2)

--- a/test/test_Quaternion.jl
+++ b/test/test_Quaternion.jl
@@ -26,7 +26,7 @@ for _ in 1:10, T in (Float32, Float64, Int32, Int64)
 end
 
 let # test rotations
-    @test_throws ErrorException qrotation([0, 0, 0], 1.0) # test that an invalid rotation axis yields an error
+    @test qrotation([0, 0, 0], 1.0) == Quaternion(1.0) # a zero axis should act like zero rotation
     @test qrotation([1, 0, 0], 0.0) == Quaternion(1.0)
     @test qrotation([0, 0, 0]) == Quaternion(1.0)
     qx = qrotation([1, 0, 0], pi / 4)

--- a/test/test_Quaternion.jl
+++ b/test/test_Quaternion.jl
@@ -25,6 +25,9 @@ for _ in 1:10, T in (Float32, Float64, Int32, Int64)
 end
 
 let # test rotations
+    @test_throws ErrorException qrotation([0, 0, 0], 1.0) # test that an invalid rotation axis yields an error
+    @test qrotation([1, 0, 0], 0.0) == Quaternion(1.0)
+    @test qrotation([0, 0, 0]) == Quaternion(1.0)
     qx = qrotation([1, 0, 0], pi / 4)
     @test qx * qx ≈ qrotation([1, 0, 0], pi / 2)
     @test qx^2 ≈ qrotation([1, 0, 0], pi / 2)


### PR DESCRIPTION
This PR is intended to remove the piracy of `LinearAlgebra.normalize(::Vector)` that was previously being committed by Quaternions. This piracy would make `normalize(zeros(3))` return a vector of `0.0` when it would normally return a vector of `NaN`.

The guilty method was only used in `qrotation(::Vector,::Any)` so it was easy enough to remove it and provide the matching calculation in its place. I also noticed that `qrotation([0,0,0],1.0) == Quaternion(0.8775825618903728, 0.0, 0.0, 0.0, true)`, which is wrong in multiple capacities. I have made it an error to use this method with a zero vector in the first argument. A potential alternative would be to force the rotation angle to zero in this case, but I opted for the error since a zero axis seemed more likely to be used in error than deliberately (given that `qrotation(::Vector)` is available for the latter case).

Along the way, I noticed that the related method `qrotation(::Vector)` was type-unstable for zero inputs and that input vectors with `NaN` entries failed to propagate their `NaN`s. Both of these issues are resolved by making it mirror the changes already made to the 2-arg method.