### PR TITLE
Add convenient type-aliases

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Quaternions"
 uuid = "94ee1d12-ae83-5a48-8b1c-48b8ff168ae0"
-version = "0.4.5"
+version = "0.4.6"
 
 [deps]
 DualNumbers = "fa6b7ba4-c1ee-5f82-b5fc-ecf0adba8f74"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Quaternions"
 uuid = "94ee1d12-ae83-5a48-8b1c-48b8ff168ae0"
-version = "0.4.6"
+version = "0.4.7"
 
 [deps]
 DualNumbers = "fa6b7ba4-c1ee-5f82-b5fc-ecf0adba8f74"

--- a/src/DualQuaternion.jl
+++ b/src/DualQuaternion.jl
@@ -21,6 +21,10 @@ DualQuaternion(q::Quaternion) = DualQuaternion(q, zero(q), q.norm)
 
 DualQuaternion(a::Vector) = DualQuaternion(zero(Quaternion{typeof(a[1])}), Quaternion(a))
 
+const DualQuaternionF16 = DualQuaternion{Float16}
+const DualQuaternionF32 = DualQuaternion{Float32}
+const DualQuaternionF64 = DualQuaternion{Float64}
+
 convert(::Type{DualQuaternion{T}}, x::Real) where {T} =
     DualQuaternion(convert(Quaternion{T}, x), convert(Quaternion{T}, 0))
 

--- a/src/Octonion.jl
+++ b/src/Octonion.jl
@@ -18,6 +18,10 @@ Octonion(q::Quaternion) = Octonion(q.s, q.v1, q.v2, q.v3, zero(q.s), zero(q.s), 
 Octonion(s::Real, a::Vector) = Octonion(s, a[1], a[2], a[3], a[4], a[5], a[6], a[7])
 Octonion(a::Vector) = Octonion(0, a[1], a[2], a[3], a[4], a[5], a[6], a[7])
 
+const OctonionF16 = Octonion{Float16}
+const OctonionF32 = Octonion{Float32}
+const OctonionF64 = Octonion{Float64}
+
 convert(::Type{Octonion{T}}, x::Real) where {T} =
   Octonion(convert(T, x), convert(T, 0), convert(T, 0), convert(T, 0), convert(T, 0), convert(T, 0), convert(T, 0), convert(T, 0))
 convert(::Type{Octonion{T}}, z::Complex) where {T} =

--- a/src/Quaternion.jl
+++ b/src/Quaternion.jl
@@ -6,6 +6,10 @@ struct Quaternion{T<:Real} <: Number
     norm::Bool
 end
 
+const QuaternionF16 = Quaternion{Float16}
+const QuaternionF32 = Quaternion{Float32}
+const QuaternionF64 = Quaternion{Float64}
+
 (::Type{Quaternion{T}})(x::Real) where {T} = Quaternion{T}(x, 0, 0, 0, false)
 (::Type{Quaternion{T}})(q::Quaternion{T}) where {T<:Real} = q
 (::Type{Quaternion{T}})(q::Quaternion) where {T<:Real} = Quaternion{T}(q.s, q.v1, q.v2, q.v3, q.norm)

--- a/src/Quaternions.jl
+++ b/src/Quaternions.jl
@@ -15,11 +15,20 @@ module Quaternions
   include("Octonion.jl")
   include("DualQuaternion.jl")
 
-  export Quaternion
+  export Quaternion,
+    QuaternionF16,
+    QuaternionF32,
+    QuaternionF64,
+    Octonion,
+    OctonionF16,
+    OctonionF32,
+    OctonionF64,
+    DualQuaternion,
+    DualQuaternionF16,
+    DualQuaternionF32,
+    DualQuaternionF64
   export quat
-  export Octonion
   export octo
-  export DualQuaternion
   export dualquat
   export angleaxis
   export angle

--- a/test/test_Quaternion.jl
+++ b/test/test_Quaternion.jl
@@ -3,6 +3,18 @@ using Quaternions: argq
 using LinearAlgebra
 using Random
 
+@testset "type aliases" begin
+    @test QuaternionF16 === Quaternion{Float16}
+    @test QuaternionF32 === Quaternion{Float32}
+    @test QuaternionF64 === Quaternion{Float64}
+    @test OctonionF16 === Octonion{Float16}
+    @test OctonionF32 === Octonion{Float32}
+    @test OctonionF64 === Octonion{Float64}
+    @test DualQuaternionF16 === DualQuaternion{Float16}
+    @test DualQuaternionF32 === DualQuaternion{Float32}
+    @test DualQuaternionF64 === DualQuaternion{Float64}
+end
+
 # creating random examples
 sample(QT::Type{Quaternion{T}}) where {T <: Integer} = QT(rand(-100:100, 4)..., false)
 sample(QT::Type{Quaternion{T}}) where {T <: AbstractFloat} = QT(rand(Bool) ? quatrand() : nquatrand())


### PR DESCRIPTION
`Complex` has the convenient type-aliases `ComplexF16`, `ComplexF32`, and `Complex64` for floating-point types, as does `Dual`. This PR adds and exports the same type-aliases for our types.