### PR TITLE
Implement sylvester and lyap for quaternions

### DIFF
--- a/src/Quaternion.jl
+++ b/src/Quaternion.jl
@@ -56,6 +56,7 @@ abs2(q::Quaternion) = q.s * q.s + q.v1 * q.v1 + q.v2 * q.v2 + q.v3 * q.v3
 inv(q::Quaternion) = q.norm ? conj(q) : conj(q) / abs2(q)
 
 isfinite(q::Quaternion) = q.norm ? true : (isfinite(q.s) && isfinite(q.v1) && isfinite(q.v2) && isfinite(q.v3))
+iszero(q::Quaternion) = ~q.norm & iszero(real(q)) & iszero(q.v1) & iszero(q.v2) & iszero(q.v3)
 
 function normalize(q::Quaternion)
     if (q.norm)

--- a/src/Quaternion.jl
+++ b/src/Quaternion.jl
@@ -307,3 +307,23 @@ function slerp(qa::Quaternion{T}, qb::Quaternion{T}, t::T) where {T}
         qa.v3 * ratio_a + qm.v3 * ratio_b,
     )
 end
+
+function sylvester(a::Quaternion, b::Quaternion, c::Quaternion)
+    abs2a = abs2(a)
+    abs2b = abs2(b)
+    if abs2a > abs2b
+        d1 = -(2real(b) + a + conj(a) * (abs2b / abs2a))
+        x = d1 \ (c + (conj(a) * c * conj(b)) / abs2a)
+    else
+        d2 = -(2real(a) + b + conj(b) * (abs2a / abs2b))
+        x = (c + (conj(a) * c * conj(b)) / abs2b) / d2
+    end
+    iszero(abs2a) && iszero(abs2b) && iszero(c) && return zero(x)
+    return x
+end
+
+function lyap(a::Quaternion, c::Quaternion)
+    x = (c + a \ c * a) / -4real(a)
+    iszero(a) && iszero(c) && return zero(x)
+    return x
+end

--- a/src/Quaternions.jl
+++ b/src/Quaternions.jl
@@ -3,7 +3,7 @@ __precompile__()
 module Quaternions
 
   import Base: +, -, *, /, ^, ==
-  import Base: abs, abs2, angle, conj, cos, exp, inv, isfinite, log, real, sin, sqrt
+  import Base: abs, abs2, angle, conj, cos, exp, inv, isfinite, iszero, log, real, sin, sqrt
   import Base: convert, promote_rule, float
   import Base: rand, randn
   import LinearAlgebra: norm, normalize

--- a/src/Quaternions.jl
+++ b/src/Quaternions.jl
@@ -6,7 +6,7 @@ module Quaternions
   import Base: abs, abs2, angle, conj, cos, exp, inv, isfinite, iszero, log, real, sin, sqrt
   import Base: convert, promote_rule, float
   import Base: rand, randn
-  import LinearAlgebra: norm, normalize
+  import LinearAlgebra: lyap, norm, normalize, sylvester
   using Random
 
   Base.@irrational INV_SQRT_EIGHT 0.3535533905932737622004 sqrt(big(0.125))

--- a/test/test_Quaternion.jl
+++ b/test/test_Quaternion.jl
@@ -349,3 +349,18 @@ end
         end
     end
 end
+
+@testset "sylvester/lyap" begin
+    a, b, c = randn(QuaternionF64, 3)
+    x = sylvester(a, b, c)
+    @test a * x + x * b ≈ -c
+    @test iszero(sylvester(a, b, zero(c)))
+    @test sylvester(a, zero(b), c) ≈ a \ -c
+    @test sylvester(zero(a), b, c) ≈ -c / b
+    @test iszero(sylvester(zero(a), zero(b), zero(c)))
+
+    @test lyap(a, c) ≈ sylvester(a, a', c)
+    @test lyap(b, c) ≈ sylvester(b, b', c)
+    @test iszero(lyap(a, zero(c)))
+    @test iszero(lyap(zero(a), zero(c)))
+end

--- a/test/test_Quaternion.jl
+++ b/test/test_Quaternion.jl
@@ -102,6 +102,15 @@ end
     @test convert(Octonion{Float64},Octonion(1,2,3,4,5,6,7,8)) === Octonion(1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0)
 end
 
+@testset "iszero" begin
+    @test iszero(Quaternion(0.0, 0.0, 0.0, 0.0))
+    @test !iszero(Quaternion(1.0, 0.0, 0.0, 0.0))
+    @test !iszero(Quaternion(0.0, 1.0, 0.0, 0.0))
+    @test !iszero(Quaternion(0.0, 0.0, 1.0, 0.0))
+    @test !iszero(Quaternion(0.0, 0.0, 0.0, 1.0))
+    @test !iszero(Quaternion(0.0, 0.0, 0.0, 0.0, true))
+end
+
 @testset "rotations" begin # test rotations
     @test qrotation([0, 0, 0], 1.0) == Quaternion(1.0) # a zero axis should act like zero rotation
     @test qrotation([1, 0, 0], 0.0) == Quaternion(1.0)


### PR DESCRIPTION
Fixes #20. Instead of mapping to matrices, it uses the following approach:

```
ax + xb + c = 0                                               # (1)
|a|^2 x b' + a' x |b|^2 + a' c b' = 0                         # (2) left- and right-multiply (1) by a' and b', respectively
x b' + a' x (|b|/|a|)^2 + a' c b'/|a|^2 = 0                   # (3) assume |a|>0 and divide by |a|^2
(2 re(b) x + a + a' (|b|/|a|)^2) x + c + a' c b'/|a|^2 = 0    # (4) add (1) and (3), and collect terms
-(2 re(b) x + a + a' (|b|/|a|)^2) x = c + a' c b'/|a|^2       # (5) rearrange
x = -(2 re(b) x + a + a' (|b|/|a|)^2) \ (c + a' c b'/|a|^2)   # (6) solve for x
```

For greater stability, if `|b| > |a|`, then we divide by `|b|^2` in (3), and continue.