### PR TITLE
update exp tests for `norm` flag

### DIFF
--- a/test/test_Quaternion.jl
+++ b/test/test_Quaternion.jl
@@ -231,11 +231,11 @@ for _ in 1:100
 end
 
 @testset "exp" begin
-    @test exp(Quaternion(0, 0, 0, 0)) == Quaternion(1, 0, 0, 0, true)
-    @test exp(Quaternion(2, 0, 0, 0)) == Quaternion(exp(2), 0, 0, 0, false)
-    @test exp(Quaternion(0, 2, 0, 0)) == Quaternion(cos(2), sin(2), 0, 0, true)
-    @test exp(Quaternion(0, 0, 2, 0)) == Quaternion(cos(2), 0, sin(2), 0, true)
-    @test exp(Quaternion(0, 0, 0, 2)) == Quaternion(cos(2), 0, 0, sin(2), true)
+    @test exp(Quaternion(0, 0, 0, 0)) === Quaternion(1., 0., 0., 0., true)
+    @test exp(Quaternion(2, 0, 0, 0)) === Quaternion(exp(2), 0, 0, 0, false)
+    @test exp(Quaternion(0, 2, 0, 0)) === Quaternion(cos(2), sin(2), 0, 0, true)
+    @test exp(Quaternion(0, 0, 2, 0)) === Quaternion(cos(2), 0, sin(2), 0, true)
+    @test exp(Quaternion(0, 0, 0, 2)) === Quaternion(cos(2), 0, 0, sin(2), true)
 
     @test norm(exp(Quaternion(0, 0, 0, 0))) ≈ 1
     @test norm(exp(Quaternion(2, 0, 0, 0))) ≠ 1
@@ -243,11 +243,11 @@ end
     @test norm(exp(Quaternion(0, 0, 2, 0))) ≈ 1
     @test norm(exp(Quaternion(0, 0, 0, 2))) ≈ 1
 
-    @test exp(Quaternion(0., 0., 0., 0.)) == Quaternion(1, 0, 0, 0, true)
-    @test exp(Quaternion(2., 0., 0., 0.)) == Quaternion(exp(2), 0, 0, 0, false)
-    @test exp(Quaternion(0., 2., 0., 0.)) == Quaternion(cos(2), sin(2), 0, 0, true)
-    @test exp(Quaternion(0., 0., 2., 0.)) == Quaternion(cos(2), 0, sin(2), 0, true)
-    @test exp(Quaternion(0., 0., 0., 2.)) == Quaternion(cos(2), 0, 0, sin(2), true)
+    @test exp(Quaternion(0., 0., 0., 0.)) === Quaternion(1., 0., 0., 0., true)
+    @test exp(Quaternion(2., 0., 0., 0.)) === Quaternion(exp(2), 0, 0, 0, false)
+    @test exp(Quaternion(0., 2., 0., 0.)) === Quaternion(cos(2), sin(2), 0, 0, true)
+    @test exp(Quaternion(0., 0., 2., 0.)) === Quaternion(cos(2), 0, sin(2), 0, true)
+    @test exp(Quaternion(0., 0., 0., 2.)) === Quaternion(cos(2), 0, 0, sin(2), true)
 
     @test norm(exp(Quaternion(0., 0., 0., 0.))) ≈ 1
     @test norm(exp(Quaternion(2., 0., 0., 0.))) ≠ 1


### PR DESCRIPTION
With #52 merged, the `==` method no longer checks the `norm` field. This PR fixes the problem in the test.