### PR TITLE
Add documentation with Documenter.jl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,19 @@ jobs:
       - uses: codecov/codecov-action@v1
         with:
           file: lcov.info
+  docs:
+    name: Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: '1'
+      - run: julia --project=docs -e '
+          using Pkg;
+          Pkg.develop(PackageSpec(; path=pwd()));
+          Pkg.instantiate();'
+      - run: julia --project=docs docs/make.jl
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-/Manifest.toml
+Manifest.toml
 /test/coverage/Manifest.toml
+docs/build

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Quaternions.jl
 A Julia module with quaternion, octonion and dual-quaternion functionality
 
+[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://JuliaGeometry.github.io/Quaternions.jl/stable)
+[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://JuliaGeometry.github.io/Quaternions.jl/dev)
 [![Build Status](https://github.com/JuliaGeometry/Quaternions.jl/workflows/CI/badge.svg)](https://github.com/JuliaGeometry/Quaternions.jl/actions?query=workflow%3ACI+branch%3Amaster)
 [![codecov](https://codecov.io/gh/JuliaGeometry/Quaternions.jl/branch/master/graph/badge.svg?token=dJBiR91dCD)](https://codecov.io/gh/JuliaGeometry/Quaternions.jl)
 

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,2 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-Quaternions = "94ee1d12-ae83-5a48-8b1c-48b8ff168ae0"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Quaternions = "94ee1d12-ae83-5a48-8b1c-48b8ff168ae0"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,22 @@
+using Quaternions
+using Documenter
+
+DocMeta.setdocmeta!(Quaternions, :DocTestSetup, :(using Quaternions); recursive=true)
+
+makedocs(;
+    modules=[Quaternions],
+    repo="https://github.com/JuliaGeometry/Quaternions.jl/blob/{commit}{path}#{line}",
+    sitename="Quaternions.jl",
+    format=Documenter.HTML(;
+        prettyurls=get(ENV, "CI", "false") == "true",
+        canonical="https://JuliaGeometry.github.io/Quaternions.jl",
+        assets = ["assets/custom.css"],
+    ),
+    pages=[
+        "Home" => "index.md",
+    ],
+)
+
+deploydocs(;
+    repo="github.com/JuliaGeometry/Quaternions.jl",
+)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,25 @@
+# Quaternions.jl
+
+A Julia module with [quaternion](https://en.wikipedia.org/wiki/Quaternion), [octonion](https://en.wikipedia.org/wiki/Octonion) and [dual-quaternion](https://en.wikipedia.org/wiki/Dual_quaternion) functionality
+
+!!! note "Documentation"
+    The documentation is still work in progress.
+    For more information, see also
+    * [README in the repository](https://github.com/JuliaGeometry/Quaternions.jl)
+    * [Tests in the repository](https://github.com/JuliaGeometry/Quaternions.jl/tree/master/test)
+    Feel free to [open pull requests](https://github.com/JuliaGeometry/Quaternions.jl/pulls) and improve this document!
+
+## Installation
+```
+pkg> add Quaternions
+```
+
+## First example
+
+```@repl
+using Quaternions
+q = quat(0.0, 0.0, 0.0, 1.0)
+r = quat(0, 0, 1, 0)
+q*r
+q+r
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,6 +1,6 @@
 # Quaternions.jl
 
-A Julia module with [quaternion](https://en.wikipedia.org/wiki/Quaternion), [octonion](https://en.wikipedia.org/wiki/Octonion) and [dual-quaternion](https://en.wikipedia.org/wiki/Dual_quaternion) functionality
+A Julia package implementing [quaternions](https://en.wikipedia.org/wiki/Quaternion), [octonions](https://en.wikipedia.org/wiki/Octonion) and [dual-quaternions](https://en.wikipedia.org/wiki/Dual_quaternion)
 
 !!! note "Documentation"
     The documentation is still work in progress.


### PR DESCRIPTION
This PR adds documentation with Documenter.jl. Note that the documentation is still incomplete.

![image](https://user-images.githubusercontent.com/7488140/155147281-0fe1cebe-8afb-4041-8bec-22a20a230add.png)
