### PR TITLE
Add isunit and change norm field to property

### DIFF
--- a/src/DualQuaternion.jl
+++ b/src/DualQuaternion.jl
@@ -8,6 +8,10 @@ Base.@deprecate(
     DualQuaternion{T}(q0, qe)
 )
 Base.@deprecate(
+    DualQuaternion{T}(d1::Dual, d2::Dual, d3::Dual, d4::Dual, norm::Bool) where {T<:Real},
+    DualQuaternion{T}(d1, d2, d3, d4)
+)
+Base.@deprecate(
     DualQuaternion(q0::Quaternion, qe::Quaternion, norm::Bool),
     DualQuaternion(q0, qe)
 )

--- a/src/DualQuaternion.jl
+++ b/src/DualQuaternion.jl
@@ -15,9 +15,9 @@ DualQuaternion(d1::Dual, d2::Dual, d3::Dual, d4::Dual, n::Bool) =
   DualQuaternion(Quaternion(DualNumbers.value(d1), DualNumbers.value(d2), DualNumbers.value(d3), DualNumbers.value(d4), n),
                   Quaternion(DualNumbers.epsilon(d1), DualNumbers.epsilon(d2), DualNumbers.epsilon(d3), DualNumbers.epsilon(d4)), n)
 
-DualQuaternion(x::Real) = DualQuaternion(Quaternion(x), Quaternion(zero(x)), abs(x) == one(x))
+DualQuaternion(x::Real) = DualQuaternion(Quaternion(x), Quaternion(zero(x)), isunit(x))
 
-DualQuaternion(d::Dual) = DualQuaternion(Quaternion(DualNumbers.value(d)), Quaternion(DualNumbers.epsilon(d)), (DualNumbers.value(d)==one(DualNumbers.value(d))) & iszero(DualNumbers.epsilon(d)))
+DualQuaternion(d::Dual) = DualQuaternion(Quaternion(DualNumbers.value(d)), Quaternion(DualNumbers.epsilon(d)), isunit(d))
 
 DualQuaternion(q::Quaternion) = DualQuaternion(q, zero(q), isunit(q))
 

--- a/src/DualQuaternion.jl
+++ b/src/DualQuaternion.jl
@@ -3,7 +3,6 @@ using DualNumbers
 struct DualQuaternion{T<:Real} <: Number
   q0::Quaternion{T}
   qe::Quaternion{T}
-  norm::Bool
 end
 
 DualQuaternion(q0::Quaternion, qe::Quaternion, n::Bool = false) =
@@ -50,6 +49,14 @@ dualquat(q1, q2, n) = DualQuaternion(q1, q2, n)
 dualquat(d1, d2, d3, d4) = DualQuaternion(d1, d2, d3, d4)
 dualquat(d1, d2, d3, d4, n) = DualQuaternion(d1, d2, d3, d4, n)
 dualquat(x) = DualQuaternion(x)
+
+function Base.getproperty(dq::DualQuaternion, k::Symbol)
+  if k === :norm
+      Base.depwarn("`dq.norm` is deprecated. Please use `isunit(dq)` instead.", Symbol("dq.norm"))
+      return isunit(dq)
+  end
+  return getfield(dq, k)
+end
 
 function show(io::IO, dq::DualQuaternion)
   show(io, dq.q0)

--- a/src/DualQuaternion.jl
+++ b/src/DualQuaternion.jl
@@ -84,6 +84,7 @@ abs2(dq::DualQuaternion) = dq.norm ? dual(one(dq.q0.s)) :
                 dq.q0.v3 * dq.qe.v3))
 
 abs(dq::DualQuaternion) = dq.norm ? dual(one(dq.q0.s)) : sqrt(abs2(dq))
+isunit(o::Octonion) = isone(abs2(o))
 float(dq::DualQuaternion{T}) where T = convert(DualQuaternion{float(T)}, dq)
 
 conj(dq::DualQuaternion) = DualQuaternion(conj(dq.q0), conj(dq.qe), dq.norm)

--- a/src/DualQuaternion.jl
+++ b/src/DualQuaternion.jl
@@ -1,5 +1,3 @@
-using DualNumbers
-
 struct DualQuaternion{T<:Real} <: Number
   q0::Quaternion{T}
   qe::Quaternion{T}
@@ -82,8 +80,6 @@ abs2(dq::DualQuaternion) = isunit(dq) ? dual(one(dq.q0.s)) :
                 dq.q0.v1 * dq.qe.v1 +
                 dq.q0.v2 * dq.qe.v2 +
                 dq.q0.v3 * dq.qe.v3))
-
-isunit(o::Octonion) = isone(abs2(o))
 
 abs(dq::DualQuaternion) = isunit(dq) ? dual(one(dq.q0.s)) : sqrt(abs2(dq))
 float(dq::DualQuaternion{T}) where T = convert(DualQuaternion{float(T)}, dq)

--- a/src/Octonion.jl
+++ b/src/Octonion.jl
@@ -64,6 +64,8 @@ float(q::Octonion{T}) where T = convert(Octonion{float(T)}, q)
 abs2(o::Octonion) = o.s * o.s + o.v1 * o.v1 + o.v2 * o.v2  + o.v3 * o.v3 + o.v4 * o.v4 + o.v5 * o.v5 + o.v6 * o.v6 + o.v7 * o.v7
 inv(o::Octonion) = o.norm ? conj(o) : conj(o) / abs2(o)
 
+isunit(o::Octonion) = isone(abs2(o))
+
 function normalize(o::Octonion)
   if (o.norm)
     return o

--- a/src/Octonion.jl
+++ b/src/Octonion.jl
@@ -7,7 +7,6 @@ struct Octonion{T<:Real} <: Number
   v5::T
   v6::T
   v7::T
-  norm::Bool
 end
 
 Octonion(s::Real, v1::Real, v2::Real, v3::Real, v4::Real, v5::Real, v6::Real, v7::Real, n::Bool = false) =
@@ -40,6 +39,14 @@ octo(p, v1, v2, v3, v4, v5, v6, v7) = Octonion(p, v1, v2, v3, v4, v5, v6, v7)
 octo(p, v1, v2, v3, v4, v5, v6, v7, n) = Octonion(p, v1, v2, v3, v4, v5, v6, v7, n)
 octo(x) = Octonion(x)
 octo(s, a) = Octonion(s, a)
+
+function Base.getproperty(o::Octonion, k::Symbol)
+  if k === :norm
+      Base.depwarn("`o.norm` is deprecated. Please use `isunit(o)` instead.", Symbol("o.norm"))
+      return isunit(o)
+  end
+  return getfield(o, k)
+end
 
 function show(io::IO, o::Octonion)
   pm(x) = x < 0 ? " - $(-x)" : " + $x"

--- a/src/Octonion.jl
+++ b/src/Octonion.jl
@@ -9,11 +9,9 @@ struct Octonion{T<:Real} <: Number
   v7::T
 end
 
-Octonion(s::Real, v1::Real, v2::Real, v3::Real, v4::Real, v5::Real, v6::Real, v7::Real, n::Bool = false) =
-  Octonion(promote(s, v1, v2, v3, v4, v5, v6, v7)..., n)
-Octonion(x::Real) = Octonion(x, zero(x), zero(x), zero(x), zero(x), zero(x), zero(x), zero(x), isunit(x))
-Octonion(z::Complex) = Octonion(z.re, z.im, zero(z.re), zero(z.re), zero(z.re), zero(z.re), zero(z.re), zero(z.re), isunit(z))
-Octonion(q::Quaternion) = Octonion(q.s, q.v1, q.v2, q.v3, zero(q.s), zero(q.s), zero(q.s), zero(q.s), isunit(q))
+Octonion(x::Real) = Octonion(x, zero(x), zero(x), zero(x), zero(x), zero(x), zero(x), zero(x))
+Octonion(z::Complex) = Octonion(z.re, z.im, zero(z.re), zero(z.re), zero(z.re), zero(z.re), zero(z.re), zero(z.re))
+Octonion(q::Quaternion) = Octonion(q.s, q.v1, q.v2, q.v3, zero(q.s), zero(q.s), zero(q.s), zero(q.s))
 Octonion(s::Real, a::Vector) = Octonion(s, a[1], a[2], a[3], a[4], a[5], a[6], a[7])
 Octonion(a::Vector) = Octonion(0, a[1], a[2], a[3], a[4], a[5], a[6], a[7])
 
@@ -26,7 +24,7 @@ convert(::Type{Octonion{T}}, z::Complex) where {T} = Octonion(convert(Complex{T}
 convert(::Type{Octonion{T}}, q::Quaternion) where {T} = Octonion(convert(Quaternion{T}, q))
 convert(::Type{Octonion{T}}, o::Octonion{T}) where {T <: Real} = o
 convert(::Type{Octonion{T}}, o::Octonion) where {T} =
-  Octonion(convert(T, o.s), convert(T, o.v1), convert(T, o.v2), convert(T, o.v3), convert(T, o.v4), convert(T, o.v5), convert(T, o.v6), convert(T, o.v7), isunit(o))
+  Octonion(convert(T, o.s), convert(T, o.v1), convert(T, o.v2), convert(T, o.v3), convert(T, o.v4), convert(T, o.v5), convert(T, o.v6), convert(T, o.v7))
 
 promote_rule(::Type{Octonion{T}}, ::Type{T}) where {T <: Real} = Octonion{T}
 promote_rule(::Type{Octonion}, ::Type{T}) where {T <: Real} = Octonion
@@ -36,9 +34,18 @@ promote_rule(::Type{Quaternion{T}}, ::Type{Octonion{S}}) where {T <: Real, S <: 
 promote_rule(::Type{Octonion{T}}, ::Type{Octonion{S}}) where {T <: Real, S <: Real} = Octonion{promote_type(T, S)}
 
 octo(p, v1, v2, v3, v4, v5, v6, v7) = Octonion(p, v1, v2, v3, v4, v5, v6, v7)
-octo(p, v1, v2, v3, v4, v5, v6, v7, n) = Octonion(p, v1, v2, v3, v4, v5, v6, v7, n)
 octo(x) = Octonion(x)
 octo(s, a) = Octonion(s, a)
+
+Base.@deprecate(
+    Octonion{T}(s::Real, v1::Real, v2::Real, v3::Real, v4::Real, v5::Real, v6::Real, v7::Real, norm::Bool) where {T<:Real},
+    Octonion{T}(s, v1, v2, v3, v4, v5, v6, v7)
+)
+Base.@deprecate(
+    Octonion(s::Real, v1::Real, v2::Real, v3::Real, v4::Real, v5::Real, v6::Real, v7::Real, norm::Bool),
+    Octonion(s, v1, v2, v3, v4, v5, v6, v7)
+)
+Base.@deprecate octo(p, v1, v2, v3, v4, v5, v6, v7, n) octo(p, v1, v2, v3, v4, v5, v6, v7)
 
 function Base.getproperty(o::Octonion, k::Symbol)
   if k === :norm
@@ -58,7 +65,7 @@ imag(o::Octonion) = [o.v1, o.v2, o.v3, o.v4, o.v5, o.v6, o.v7]
 
 (/)(o::Octonion, x::Real) = Octonion(o.s / x, o.v1 / x, o.v2 / x, o.v3 / x, o.v4 / x, o.v5 / x, o.v6 / x, o.v7 / x)
 
-conj(o::Octonion) = Octonion(o.s, -o.v1, -o.v2, -o.v3, -o.v4, -o.v5, -o.v6, -o.v7, isunit(o))
+conj(o::Octonion) = Octonion(o.s, -o.v1, -o.v2, -o.v3, -o.v4, -o.v5, -o.v6, -o.v7)
 abs(o::Octonion) = sqrt(o.s * o.s + o.v1 * o.v1 + o.v2 * o.v2 + o.v3 * o.v3 + o.v4 * o.v4 + o.v5 * o.v5 + o.v6 * o.v6 + o.v7 * o.v7)
 float(q::Octonion{T}) where T = convert(Octonion{float(T)}, q)
 abs2(o::Octonion) = o.s * o.s + o.v1 * o.v1 + o.v2 * o.v2  + o.v3 * o.v3 + o.v4 * o.v4 + o.v5 * o.v5 + o.v6 * o.v6 + o.v7 * o.v7
@@ -69,7 +76,7 @@ function normalize(o::Octonion)
     return o
   end
   o = o / abs(o)
-  Octonion(o.s, o.v1, o.v2, o.v3, o.v4, o.v5, o.v6, o.v7, true)
+  Octonion(o.s, o.v1, o.v2, o.v3, o.v4, o.v5, o.v6, o.v7)
 end
 
 function normalizea(o::Octonion)
@@ -78,10 +85,10 @@ function normalizea(o::Octonion)
   end
   a = abs(o)
   o = o / a
-  (Octonion(o.s, o.v1, o.v2, o.v3, o.v4, o.v5, o.v6, o.v7, true), a)
+  (Octonion(o.s, o.v1, o.v2, o.v3, o.v4, o.v5, o.v6, o.v7), a)
 end
 
-(-)(o::Octonion) = Octonion(-o.s, -o.v1, -o.v2, -o.v3, -o.v4, -o.v5, -o.v6, -o.v7, isunit(o))
+(-)(o::Octonion) = Octonion(-o.s, -o.v1, -o.v2, -o.v3, -o.v4, -o.v5, -o.v6, -o.v7)
 
 (+)(o::Octonion, w::Octonion) = Octonion(o.s + w.s,
                                             o.v1 + w.v1,
@@ -140,8 +147,7 @@ function exp(o::Octonion)
             scale * o.v4,
             scale * o.v5,
             scale * o.v6,
-            scale * o.v7,
-            abs(s) == 0)
+            scale * o.v7)
 end
 
 function log(o::Octonion)
@@ -174,7 +180,7 @@ octorand() = octo(randn(), randn(), randn(), randn(), randn(), randn(), randn(),
 
 function rand(rng::AbstractRNG, ::Random.SamplerType{Octonion{T}}) where {T<:Real}
   Octonion{T}(rand(rng, T), rand(rng, T), rand(rng, T), rand(rng, T),
-              rand(rng, T), rand(rng, T), rand(rng, T), rand(rng, T), false)
+              rand(rng, T), rand(rng, T), rand(rng, T), rand(rng, T))
 end
 
 function randn(rng::AbstractRNG, ::Type{Octonion{T}}) where {T<:AbstractFloat}
@@ -187,6 +193,5 @@ function randn(rng::AbstractRNG, ::Type{Octonion{T}}) where {T<:AbstractFloat}
       randn(rng, T) * INV_SQRT_EIGHT,
       randn(rng, T) * INV_SQRT_EIGHT,
       randn(rng, T) * INV_SQRT_EIGHT,
-      false,
   )
 end

--- a/src/Octonion.jl
+++ b/src/Octonion.jl
@@ -64,8 +64,6 @@ float(q::Octonion{T}) where T = convert(Octonion{float(T)}, q)
 abs2(o::Octonion) = o.s * o.s + o.v1 * o.v1 + o.v2 * o.v2  + o.v3 * o.v3 + o.v4 * o.v4 + o.v5 * o.v5 + o.v6 * o.v6 + o.v7 * o.v7
 inv(o::Octonion) = isunit(o) ? conj(o) : conj(o) / abs2(o)
 
-isunit(o::Octonion) = isone(abs2(o))
-
 function normalize(o::Octonion)
   if (isunit(o))
     return o

--- a/src/Octonion.jl
+++ b/src/Octonion.jl
@@ -13,10 +13,10 @@ Octonion{T}(x::Real) where {T<:Real} = Octonion(convert(T, x))
 Octonion{T}(x::Complex) where {T<:Real} = Octonion(convert(Complex{T}, x))
 Octonion{T}(q::Quaternion) where {T<:Real} = Octonion(convert(Quaternion{T}, q))
 Octonion{T}(o::Octonion) where {T<:Real} =
-  Octonion{T}(o.s, o.v1, o.v2, o.v3, o.v4, o.v5, o.v6, o.v7, o.norm)
+  Octonion{T}(o.s, o.v1, o.v2, o.v3, o.v4, o.v5, o.v6, o.v7)
 
-Octonion(s::Real, v1::Real, v2::Real, v3::Real, v4::Real, v5::Real, v6::Real, v7::Real, n::Bool = false) =
-  Octonion(promote(s, v1, v2, v3, v4, v5, v6, v7)..., n)
+Octonion(s::Real, v1::Real, v2::Real, v3::Real, v4::Real, v5::Real, v6::Real, v7::Real) =
+  Octonion(promote(s, v1, v2, v3, v4, v5, v6, v7)...)
 Octonion(x::Real) = Octonion(x, zero(x), zero(x), zero(x), zero(x), zero(x), zero(x), zero(x))
 Octonion(z::Complex) = Octonion(z.re, z.im, zero(z.re), zero(z.re), zero(z.re), zero(z.re), zero(z.re), zero(z.re))
 Octonion(q::Quaternion) = Octonion(q.s, q.v1, q.v2, q.v3, zero(q.s), zero(q.s), zero(q.s), zero(q.s))
@@ -72,10 +72,10 @@ abs2(o::Octonion) = o.s * o.s + o.v1 * o.v1 + o.v2 * o.v2  + o.v3 * o.v3 + o.v4 
 inv(o::Octonion) = isunit(o) ? conj(o) : conj(o) / abs2(o)
 
 isreal(o::Octonion) = iszero(o.v1) & iszero(o.v2) & iszero(o.v3) & iszero(o.v4) & iszero(o.v5) & iszero(o.v6) & iszero(o.v7) 
-isfinite(o::Octonion) = o.norm | (isfinite(real(o)) & isfinite(o.v1) & isfinite(o.v2) & isfinite(o.v3) & isfinite(o.v4) & isfinite(o.v5) & isfinite(o.v6) & isfinite(o.v7))
-iszero(o::Octonion) = ~o.norm & iszero(real(o)) & iszero(o.v1) & iszero(o.v2) & iszero(o.v3) & iszero(o.v4) & iszero(o.v5) & iszero(o.v6) & iszero(o.v7)
+isfinite(o::Octonion) = isfinite(real(o)) & isfinite(o.v1) & isfinite(o.v2) & isfinite(o.v3) & isfinite(o.v4) & isfinite(o.v5) & isfinite(o.v6) & isfinite(o.v7)
+iszero(o::Octonion) = iszero(real(o)) & iszero(o.v1) & iszero(o.v2) & iszero(o.v3) & iszero(o.v4) & iszero(o.v5) & iszero(o.v6) & iszero(o.v7)
 isnan(o::Octonion) = isnan(real(o)) | isnan(o.v1) | isnan(o.v2) | isnan(o.v3) | isnan(o.v4) | isnan(o.v5) | isnan(o.v6) | isnan(o.v7)
-isinf(o::Octonion) = ~o.norm & (isinf(real(o)) | isinf(o.v1) | isinf(o.v2) | isinf(o.v3) | isinf(o.v4) | isinf(o.v5) | isinf(o.v6) | isinf(o.v7))
+isinf(o::Octonion) = isinf(real(o)) | isinf(o.v1) | isinf(o.v2) | isinf(o.v3) | isinf(o.v4) | isinf(o.v5) | isinf(o.v6) | isinf(o.v7)
 
 function normalize(o::Octonion)
   if (isunit(o))

--- a/src/Octonion.jl
+++ b/src/Octonion.jl
@@ -11,8 +11,8 @@ end
 
 Octonion(s::Real, v1::Real, v2::Real, v3::Real, v4::Real, v5::Real, v6::Real, v7::Real, n::Bool = false) =
   Octonion(promote(s, v1, v2, v3, v4, v5, v6, v7)..., n)
-Octonion(x::Real) = Octonion(x, zero(x), zero(x), zero(x), zero(x), zero(x), zero(x), zero(x), abs(x) == one(x))
-Octonion(z::Complex) = Octonion(z.re, z.im, zero(z.re), zero(z.re), zero(z.re), zero(z.re), zero(z.re), zero(z.re), abs(z) == one(z.re))
+Octonion(x::Real) = Octonion(x, zero(x), zero(x), zero(x), zero(x), zero(x), zero(x), zero(x), isunit(x))
+Octonion(z::Complex) = Octonion(z.re, z.im, zero(z.re), zero(z.re), zero(z.re), zero(z.re), zero(z.re), zero(z.re), isunit(z))
 Octonion(q::Quaternion) = Octonion(q.s, q.v1, q.v2, q.v3, zero(q.s), zero(q.s), zero(q.s), zero(q.s), isunit(q))
 Octonion(s::Real, a::Vector) = Octonion(s, a[1], a[2], a[3], a[4], a[5], a[6], a[7])
 Octonion(a::Vector) = Octonion(0, a[1], a[2], a[3], a[4], a[5], a[6], a[7])

--- a/src/Quaternion.jl
+++ b/src/Quaternion.jl
@@ -62,6 +62,7 @@ abs_imag(q::Quaternion) = sqrt(q.v1 * q.v1 + q.v2 * q.v2 + q.v3 * q.v3)
 abs2(q::Quaternion) = q.s * q.s + q.v1 * q.v1 + q.v2 * q.v2 + q.v3 * q.v3
 inv(q::Quaternion) = q.norm ? conj(q) : conj(q) / abs2(q)
 
+isunit(q::Quaternion) = isone(abs2(q))
 isreal(q::Quaternion) = iszero(q.v1) & iszero(q.v2) & iszero(q.v3)
 isfinite(q::Quaternion) = q.norm | (isfinite(q.s) & isfinite(q.v1) & isfinite(q.v2) & isfinite(q.v3))
 iszero(q::Quaternion) = ~q.norm & iszero(real(q)) & iszero(q.v1) & iszero(q.v2) & iszero(q.v3)

--- a/src/Quaternion.jl
+++ b/src/Quaternion.jl
@@ -3,7 +3,6 @@ struct Quaternion{T<:Real} <: Number
     v1::T
     v2::T
     v3::T
-    norm::Bool
 end
 
 const QuaternionF16 = Quaternion{Float16}
@@ -36,6 +35,14 @@ quat(p, v1, v2, v3) = Quaternion(p, v1, v2, v3)
 quat(p, v1, v2, v3, n) = Quaternion(p, v1, v2, v3, n)
 quat(x) = Quaternion(x)
 quat(s, a) = Quaternion(s, a)
+
+function Base.getproperty(q::Quaternion, k::Symbol)
+    if k === :norm
+        Base.depwarn("`q.norm` is deprecated. Please use `isunit(q)` instead.", Symbol("q.norm"))
+        return isunit(q)
+    end
+    return getfield(q, k)
+end
 
 function show(io::IO, q::Quaternion)
     pm(x) = x < 0 ? " - $(-x)" : " + $x"

--- a/src/Quaternion.jl
+++ b/src/Quaternion.jl
@@ -14,8 +14,8 @@ const QuaternionF64 = Quaternion{Float64}
 (::Type{Quaternion{T}})(q::Quaternion) where {T<:Real} = Quaternion{T}(q.s, q.v1, q.v2, q.v3, isunit(q))
 Quaternion(s::Real, v1::Real, v2::Real, v3::Real, n::Bool = false) =
     Quaternion(promote(s, v1, v2, v3)..., n)
-Quaternion(x::Real) = Quaternion(x, zero(x), zero(x), zero(x), abs(x) == one(x))
-Quaternion(z::Complex) = Quaternion(z.re, z.im, zero(z.re), zero(z.re), abs(z) == one(z.re))
+Quaternion(x::Real) = Quaternion(x, zero(x), zero(x), zero(x), isunit(x))
+Quaternion(z::Complex) = Quaternion(z.re, z.im, zero(z.re), zero(z.re), isunit(z))
 Quaternion(s::Real, a::Vector) = Quaternion(s, a[1], a[2], a[3])
 Quaternion(a::Vector) = Quaternion(0, a[1], a[2], a[3])
 

--- a/src/Quaternion.jl
+++ b/src/Quaternion.jl
@@ -28,12 +28,12 @@ quat(x) = Quaternion(x)
 quat(s, a) = Quaternion(s, a)
 
 Base.@deprecate(
-    Quaternion{T}(s::Real, v1::Real, v2::Real, v3::Real, v4::Real, norm::Bool) where {T<:Real},
+    Quaternion{T}(s::Real, v1::Real, v2::Real, v3::Real, norm::Bool) where {T<:Real},
     Quaternion{T}(s, v1, v2, v3)
 )
 Base.@deprecate(
-    Quaternion(s::Real, v1::Real, v2::Real, v3::Real, v4::Real, norm::Bool),
-    Quaternion(s, v1, v2, v3, v4)
+    Quaternion(s::Real, v1::Real, v2::Real, v3::Real, norm::Bool),
+    Quaternion(s, v1, v2, v3)
 )
 Base.@deprecate quat(p, v1, v2, v3, n) quat(p, v1, v2, v3)
 

--- a/src/Quaternion.jl
+++ b/src/Quaternion.jl
@@ -62,7 +62,6 @@ abs_imag(q::Quaternion) = sqrt(q.v1 * q.v1 + q.v2 * q.v2 + q.v3 * q.v3)
 abs2(q::Quaternion) = q.s * q.s + q.v1 * q.v1 + q.v2 * q.v2 + q.v3 * q.v3
 inv(q::Quaternion) = isunit(q) ? conj(q) : conj(q) / abs2(q)
 
-isunit(q::Quaternion) = isone(abs2(q))
 isreal(q::Quaternion) = iszero(q.v1) & iszero(q.v2) & iszero(q.v3)
 isfinite(q::Quaternion) = isunit(q) | (isfinite(q.s) & isfinite(q.v1) & isfinite(q.v2) & isfinite(q.v3))
 iszero(q::Quaternion) = ~isunit(q) & iszero(real(q)) & iszero(q.v1) & iszero(q.v2) & iszero(q.v3)

--- a/src/Quaternions.jl
+++ b/src/Quaternions.jl
@@ -8,6 +8,7 @@ module Quaternions
   import Base: rand, randn
   import LinearAlgebra: lyap, norm, normalize, sylvester
   using Random
+  using DualNumbers
 
   Base.@irrational INV_SQRT_EIGHT 0.3535533905932737622004 sqrt(big(0.125))
 
@@ -17,9 +18,11 @@ module Quaternions
   Return `true` if for the hypercomplex number `x`, `abs(x) == 1`.
   """
   function isunit end
-  isunit(x::Real) = isone(abs2(x))
-  isunit(x::Complex) = isone(abs2(x))
-  isunit(x::Dual) = isunit(DualNumbers.value(x)) & iszero(DualNumbers.epsilon(x))
+  isunit(x::Real) = isone(abs(x))
+  isunit(x::Complex) = isone(abs(x))
+  isunit(x::DualNumbers.Dual) = isunit(DualNumbers.value(x)) & iszero(DualNumbers.epsilon(x))
+  # TODO: replace this with something more efficient
+  isunit(x::Number) = isone(abs(x))
 
   include("Quaternion.jl")
   include("Octonion.jl")

--- a/src/Quaternions.jl
+++ b/src/Quaternions.jl
@@ -11,6 +11,16 @@ module Quaternions
 
   Base.@irrational INV_SQRT_EIGHT 0.3535533905932737622004 sqrt(big(0.125))
 
+  """
+      isunit(x)
+  
+  Return `true` if for the hypercomplex number `x`, `abs(x) == 1`.
+  """
+  function isunit end
+  isunit(x::Real) = isone(abs2(x))
+  isunit(x::Complex) = isone(abs2(x))
+  isunit(x::Dual) = isunit(DualNumbers.value(x)) & iszero(DualNumbers.epsilon(x))
+
   include("Quaternion.jl")
   include("Octonion.jl")
   include("DualQuaternion.jl")
@@ -30,6 +40,7 @@ module Quaternions
   export quat
   export octo
   export dualquat
+  export isunit
   export angleaxis
   export angle
   export axis


### PR DESCRIPTION
As suggested in https://github.com/JuliaGeometry/Quaternions.jl/issues/60#issuecomment-1050393987, this PR adds an exported function `isunit` for checking if a number is normalized. It also changes the `norm` field to a (deprecated) property, which just forwards to `isunit`. All constructors and shorthands that use take a boolean argument for whether the number is unit are also deprecated.

This is not a breaking change. However, it should wait until #74 is merged so that we are sure it doesn't break existing functionality.

This will close #60