### PR TITLE
Reorder operations in `*`, `abs2`

### DIFF
--- a/test/Octonion.jl
+++ b/test/Octonion.jl
@@ -295,6 +295,106 @@ using Test
         @test isnan(octo(1, 2, 3, 4, 5, 6, 7, NaN))
     end
 
+    @testset "*" begin
+        # verify basic correctness
+        q0 = Octonion(1,0,0,0,0,0,0,0)
+        q1 = Octonion(0,1,0,0,0,0,0,0)
+        q2 = Octonion(0,0,1,0,0,0,0,0)
+        q3 = Octonion(0,0,0,1,0,0,0,0)
+        q4 = Octonion(0,0,0,0,1,0,0,0)
+        q5 = Octonion(0,0,0,0,0,1,0,0)
+        q6 = Octonion(0,0,0,0,0,0,1,0)
+        q7 = Octonion(0,0,0,0,0,0,0,1)
+        @test q0 * q0 == q0
+        @test q0 * q1 == q1
+        @test q0 * q2 == q2
+        @test q0 * q3 == q3
+        @test q0 * q4 == q4
+        @test q0 * q5 == q5
+        @test q0 * q6 == q6
+        @test q0 * q7 == q7
+        @test q1 * q0 == q1
+        @test q1 * q1 == -q0
+        @test q1 * q2 == q3
+        @test q1 * q3 == -q2
+        @test q1 * q4 == -q7
+        @test q1 * q5 == -q6
+        @test q1 * q6 == q5
+        @test q1 * q7 == q4
+        @test q2 * q0 == q2
+        @test q2 * q1 == -q3
+        @test q2 * q2 == -q0
+        @test q2 * q3 == q1
+        @test q2 * q4 == q6
+        @test q2 * q5 == -q7
+        @test q2 * q6 == -q4
+        @test q2 * q7 == q5
+        @test q3 * q0 == q3
+        @test q3 * q1 == q2
+        @test q3 * q2 == -q1
+        @test q3 * q3 == -q0
+        @test q3 * q4 == -q5
+        @test q3 * q5 == q4
+        @test q3 * q6 == -q7
+        @test q3 * q7 == q6
+        @test q4 * q0 == q4
+        @test q4 * q1 == q7
+        @test q4 * q2 == -q6
+        @test q4 * q3 == q5
+        @test q4 * q4 == -q0
+        @test q4 * q5 == -q3
+        @test q4 * q6 == q2
+        @test q4 * q7 == -q1
+        @test q5 * q0 == q5
+        @test q5 * q1 == q6
+        @test q5 * q2 == q7
+        @test q5 * q3 == -q4
+        @test q5 * q4 == q3
+        @test q5 * q5 == -q0
+        @test q5 * q6 == -q1
+        @test q5 * q7 == -q2
+        @test q6 * q0 == q6
+        @test q6 * q1 == -q5
+        @test q6 * q2 == q4
+        @test q6 * q3 == q7
+        @test q6 * q4 == -q2
+        @test q6 * q5 == q1
+        @test q6 * q6 == -q0
+        @test q6 * q7 == -q3
+        @test q7 * q0 == q7
+        @test q7 * q1 == -q4
+        @test q7 * q2 == -q5
+        @test q7 * q3 == -q6
+        @test q7 * q4 == q1
+        @test q7 * q5 == q2
+        @test q7 * q6 == q3
+        @test q7 * q7 == -q0
+
+        @testset "* same between Quaternions and Octonion" begin
+            # make sure this tracks the `*` tests for Quaternions
+            q1 = Octonion(1,0,0,0,0,0,0,0)
+            qi = Octonion(0,1,0,0,0,0,0,0)
+            qj = Octonion(0,0,1,0,0,0,0,0)
+            qk = Octonion(0,0,0,1,0,0,0,0)
+            @test q1 * q1 == q1
+            @test q1 * qi == qi
+            @test q1 * qj == qj
+            @test q1 * qk == qk
+            @test qi * q1 == qi
+            @test qi * qi == -q1
+            @test qi * qj == qk
+            @test qi * qk == -qj
+            @test qj * q1 == qj
+            @test qj * qi == -qk
+            @test qj * qj == -q1
+            @test qj * qk == qi
+            @test qk * q1 == qk
+            @test qk * qi == qj
+            @test qk * qj == -qi
+            @test qk * qk == -q1
+        end
+    end
+
     @testset "/" begin
         for _ in 1:100
             o, o2 = randn(OctonionF64, 2)

--- a/test/Quaternion.jl
+++ b/test/Quaternion.jl
@@ -267,6 +267,30 @@ Base.:(/)(a::MyReal, b::Real) = a.val / b
         @test isnan(Quaternion(1, 2, 3, NaN))
     end
 
+    @testset "*" begin
+        # verify basic correctness
+        q1 = Quaternion(1,0,0,0)
+        qi = Quaternion(0,1,0,0)
+        qj = Quaternion(0,0,1,0)
+        qk = Quaternion(0,0,0,1)
+        @test q1 * q1 == q1
+        @test q1 * qi == qi
+        @test q1 * qj == qj
+        @test q1 * qk == qk
+        @test qi * q1 == qi
+        @test qi * qi == -q1
+        @test qi * qj == qk
+        @test qi * qk == -qj
+        @test qj * q1 == qj
+        @test qj * qi == -qk
+        @test qj * qj == -q1
+        @test qj * qk == qi
+        @test qk * q1 == qk
+        @test qk * qi == qj
+        @test qk * qj == -qi
+        @test qk * qk == -q1
+    end
+
     @testset "/" begin
         for _ in 1:100
             q, q2 = randn(QuaternionF64, 2)


### PR DESCRIPTION
The purpose of this PR is to re-order the operations in `*`. The primary motivator was to ensure that `q' * q == q * q' == abs2(q)` exactly, even for float operations. The previous arithmetic was dependent on lucky rounding so these equalities were only approximate. I made sure that `Octonion` matches `Quaternion` for these operations when the back half is zero, so that promotion doesn't risk changing arithmetic. I also added methods for scalar multiplication (the compiler wasn't able to compile away the zeros on its own) and some basic tests to ensure that `*` doesn't get broken by accident if somebody tries to improve it in the future.

There is also some performance improvement due to spending some time fiddling with the ordering of operations. `*(::QuaternionF64,::QuaternionF64)` goes from 4ns down to 3ns on my machine (and with #75 it looks like it might drop further to the 2.5ns ballpark). In the process I tried to get `abs2` to be as fast as possible, since #75 might make use of it. I changed `abs` to track these changes.

There are alternative orderings that could permit some `fma` instructions without breaking the target equalities and presumably be more accurate (and slightly faster on machines with native `fma`), but when I experimented with `fma` versions they weren't generating faster code. Also, it's not easy to add "fma only if native" operations right now (`muladd` can re-associate adjacent operations, not just the arguments). Maybe somebody revisits this in the future, but the gains won't be huge.