### PR TITLE
Fix test for `slerp`

### DIFF
--- a/test/Quaternion.jl
+++ b/test/Quaternion.jl
@@ -602,9 +602,9 @@ Base.:(/)(a::MyReal, b::Real) = a.val / b
                 @test slerp(a, b, 0.0).norm
                 @test slerp(a, b, 1.0).norm
                 @test slerp(a, b, 0.5).norm
-                for _ in 1:100
+                for _ in 1:100, scale in (1, 1e-5, 1e-10)
                     q1 = quat(1, 0, 0, 0.0)
-                    θ = rand() * π
+                    θ = rand() * π * scale
                     ax = randn(3)
                     q2 = qrotation(ax, θ)
                     qsmall = qrotation(ax, cbrt(eps()))

--- a/test/Quaternion.jl
+++ b/test/Quaternion.jl
@@ -604,8 +604,7 @@ Base.:(/)(a::MyReal, b::Real) = a.val / b
                 @test slerp(a, b, 0.5).norm
                 for _ in 1:100
                     q1 = quat(1, 0, 0, 0.0)
-                    # there are numerical stability issues with slerp atm
-                    θ = clamp(rand() * 3.5, deg2rad(5e-1), π)
+                    θ = rand() * π
                     ax = randn(3)
                     q2 = qrotation(ax, θ)
                     qsmall = qrotation(ax, cbrt(eps()))


### PR DESCRIPTION
We have `θ = clamp(rand() * 3.5, deg2rad(5e-1), π)` in the test for `slerp`, but this can be replaced with `θ = rand() * π`. The original issue around numerical stability was already solved in #78.