### PR TITLE
Remove unused `show` methods

### DIFF
--- a/src/DualQuaternion.jl
+++ b/src/DualQuaternion.jl
@@ -51,13 +51,6 @@ dualquat(d1, d2, d3, d4) = DualQuaternion(d1, d2, d3, d4)
 dualquat(d1, d2, d3, d4, n) = DualQuaternion(d1, d2, d3, d4, n)
 dualquat(x) = DualQuaternion(x)
 
-function show(io::IO, dq::DualQuaternion)
-  show(io, dq.q0)
-  print(io, " + ( ")
-  show(io, dq.qe)
-  print(io, " )du")
-end
-
 Q0(dq::DualQuaternion) = dq.q0
 Qe(dq::DualQuaternion) = dq.qe
 

--- a/src/Octonion.jl
+++ b/src/Octonion.jl
@@ -38,11 +38,6 @@ octo(p, v1, v2, v3, v4, v5, v6, v7, n) = Octonion(p, v1, v2, v3, v4, v5, v6, v7,
 octo(x) = Octonion(x)
 octo(s, a) = Octonion(s, a)
 
-function show(io::IO, o::Octonion)
-  pm(x) = x < 0 ? " - $(-x)" : " + $x"
-  print(io, o.s, pm(o.v1), "im", pm(o.v2), "jm", pm(o.v3), "km", pm(o.v4), "ilm", pm(o.v5), "jlm", pm(o.v6), "klm", pm(o.v7), "lm")
-end
-
 real(o::Octonion) = o.s
 imag_part(o::Octonion) = (o.v1, o.v2, o.v3, o.v4, o.v5, o.v6, o.v7)
 @deprecate imag(o::Octonion) collect(imag_part(o)) false

--- a/src/Quaternion.jl
+++ b/src/Quaternion.jl
@@ -29,11 +29,6 @@ quat(p, v1, v2, v3, n) = Quaternion(p, v1, v2, v3, n)
 quat(x) = Quaternion(x)
 quat(s, a) = Quaternion(s, a)
 
-function show(io::IO, q::Quaternion)
-    pm(x) = x < 0 ? " - $(-x)" : " + $x"
-    print(io, q.s, pm(q.v1), "im", pm(q.v2), "jm", pm(q.v3), "km")
-end
-
 real(::Type{Quaternion{T}}) where {T} = T
 real(q::Quaternion) = q.s
 imag_part(q::Quaternion) = (q.v1, q.v2, q.v3)


### PR DESCRIPTION
This PR removes `show` methods. (x-ref https://github.com/JuliaGeometry/Quaternions.jl/issues/50#issuecomment-1046323732)