### PR TITLE
Add support for `reim`

### DIFF
--- a/src/Octonion.jl
+++ b/src/Octonion.jl
@@ -45,6 +45,7 @@ end
 
 real(o::Octonion) = o.s
 imag_part(o::Octonion) = (o.v1, o.v2, o.v3, o.v4, o.v5, o.v6, o.v7)
+Base.reim(o::Octonion) = (o.s, o.v1, o.v2, o.v3, o.v4, o.v5, o.v6, o.v7)
 @deprecate imag(o::Octonion) collect(imag_part(o)) false
 
 (/)(o::Octonion, x::Real) = Octonion(o.s / x, o.v1 / x, o.v2 / x, o.v3 / x, o.v4 / x, o.v5 / x, o.v6 / x, o.v7 / x)

--- a/src/Quaternion.jl
+++ b/src/Quaternion.jl
@@ -37,6 +37,7 @@ end
 real(::Type{Quaternion{T}}) where {T} = T
 real(q::Quaternion) = q.s
 imag_part(q::Quaternion) = (q.v1, q.v2, q.v3)
+Base.reim(q::Quaternion) = (q.s, q.v1, q.v2, q.v3)
 @deprecate imag(q::Quaternion) collect(imag_part(q)) false
 
 (/)(q::Quaternion, x::Real) = Quaternion(q.s / x, q.v1 / x, q.v2 / x, q.v3 / x)

--- a/test/DualQuaternion.jl
+++ b/test/DualQuaternion.jl
@@ -202,6 +202,7 @@ end
         @test_throws MethodError imag(q)
         @test_throws MethodError Quaternions.imag(q)
         @test_throws MethodError imag_part(q)
+        @test_throws MethodError reim(q)
         @test conj(q) === dualquat(conj(q.q0), conj(q.qe), q.norm)
         @test conj(qnorm) === dualquat(conj(qnorm.q0), conj(qnorm.qe), qnorm.norm)
         @test conj(conj(q)) === q

--- a/test/Octonion.jl
+++ b/test/Octonion.jl
@@ -170,6 +170,7 @@ using Test
         @test_throws MethodError imag(q)
         @test @test_deprecated(Quaternions.imag(q)) == [q.v1, q.v2, q.v3, q.v4, q.v5, q.v6, q.v7]
         @test imag_part(q) === (q.v1, q.v2, q.v3, q.v4, q.v5, q.v6, q.v7)
+        @test reim(q) === (q.s, q.v1, q.v2, q.v3, q.v4, q.v5, q.v6, q.v7)
         @test conj(q) ===
             Octonion(q.s, -q.v1, -q.v2, -q.v3, -q.v4, -q.v5, -q.v6, -q.v7, q.norm)
         @test conj(qnorm) === Octonion(

--- a/test/Quaternion.jl
+++ b/test/Quaternion.jl
@@ -180,6 +180,7 @@ Base.:(/)(a::MyReal, b::Real) = a.val / b
         @test_throws MethodError imag(q)
         @test @test_deprecated(Quaternions.imag(q)) == [q.v1, q.v2, q.v3]
         @test imag_part(q) === (q.v1, q.v2, q.v3)
+        @test reim(q) === (q.s, q.v1, q.v2, q.v3)
         @test conj(q) === Quaternion(q.s, -q.v1, -q.v2, -q.v3, q.norm)
         @test conj(qnorm) === Quaternion(qnorm.s, -qnorm.v1, -qnorm.v2, -qnorm.v3, true)
         @test conj(conj(q)) === q


### PR DESCRIPTION
The method `Base.imag(q::Quaternion)` should not be defined because the output type must be changed, but `Base.reim(c::Complex)` is a `Tuple`, so `Base.reim(q::Quaternion)` can be defined with return type `Tuple`.