### PR TITLE
Add deprecated messages for `DualQuaternion`

### DIFF
--- a/src/DualQuaternion.jl
+++ b/src/DualQuaternion.jl
@@ -4,14 +4,14 @@ struct DualQuaternion{T<:Real} <: Number
   q0::Quaternion{T}
   qe::Quaternion{T}
   norm::Bool
-  function DualQuaternion(q0::Quaternion{T}, qe::Quaternion{T}, norm::Bool) where T <: Real
-    Base.depwarn("`DualQuaternion` will be removed in the next breaking release. Use `Quaternion{ForwardDiff.Dual}` instead.", :DualQuaternion)
-    return new{T}(q0, qe, norm)
-  end
   function DualQuaternion{T}(q0::Quaternion, qe::Quaternion, norm::Bool) where T <: Real
-    Base.depwarn("`DualQuaternion` will be removed in the next breaking release. Use `Quaternion{ForwardDiff.Dual}` instead.", :DualQuaternion)
+    Base.depwarn("`DualQuaternion` is deprecated and will be removed in the next breaking release. Use `Quaternion{ForwardDiff.Dual}` instead.", :DualQuaternion)
     return new{T}(q0, qe, norm)
   end
+end
+
+function DualQuaternion(q0::Quaternion{T}, qe::Quaternion{T}, norm::Bool) where T <: Real
+  return DualQuaternion{T}(q0, qe, norm)
 end
 
 DualQuaternion{T}(dq::DualQuaternion) where {T<:Real} = DualQuaternion{T}(dq.q0, dq.qe, dq.norm)

--- a/src/DualQuaternion.jl
+++ b/src/DualQuaternion.jl
@@ -4,6 +4,14 @@ struct DualQuaternion{T<:Real} <: Number
   q0::Quaternion{T}
   qe::Quaternion{T}
   norm::Bool
+  function DualQuaternion(q0::Quaternion{T}, qe::Quaternion{T}, norm::Bool) where T <: Real
+    Base.depwarn("`DualQuaternion` will be removed in the next breaking release. Use `Quaternion{ForwardDiff.Dual}` instead.", :DualQuaternion)
+    return new{T}(q0, qe, norm)
+  end
+  function DualQuaternion{T}(q0::Quaternion, qe::Quaternion, norm::Bool) where T <: Real
+    Base.depwarn("`DualQuaternion` will be removed in the next breaking release. Use `Quaternion{ForwardDiff.Dual}` instead.", :DualQuaternion)
+    return new{T}(q0, qe, norm)
+  end
 end
 
 DualQuaternion{T}(dq::DualQuaternion) where {T<:Real} = DualQuaternion{T}(dq.q0, dq.qe, dq.norm)

--- a/src/DualQuaternion.jl
+++ b/src/DualQuaternion.jl
@@ -4,7 +4,7 @@ struct DualQuaternion{T<:Real} <: Number
   q0::Quaternion{T}
   qe::Quaternion{T}
   norm::Bool
-  function DualQuaternion{T}(q0, qe, norm) where T
+  function DualQuaternion{T}(q0, qe, norm) where T <: Real
     Base.depwarn("`DualQuaternion` is deprecated and will be removed in the next breaking release. Use `Quaternion{ForwardDiff.Dual}` instead.", :DualQuaternion)
     return new{T}(q0, qe, norm)
   end

--- a/src/DualQuaternion.jl
+++ b/src/DualQuaternion.jl
@@ -4,7 +4,7 @@ struct DualQuaternion{T<:Real} <: Number
   q0::Quaternion{T}
   qe::Quaternion{T}
   norm::Bool
-  function DualQuaternion{T}(q0::Quaternion, qe::Quaternion, norm::Bool) where T <: Real
+  function DualQuaternion{T}(q0, qe, norm) where T
     Base.depwarn("`DualQuaternion` is deprecated and will be removed in the next breaking release. Use `Quaternion{ForwardDiff.Dual}` instead.", :DualQuaternion)
     return new{T}(q0, qe, norm)
   end

--- a/test/DualQuaternion.jl
+++ b/test/DualQuaternion.jl
@@ -113,8 +113,8 @@ end
 
     @testset "deprecated warning" begin
         @test_deprecated DualQuaternion(Quaternion(1, 2, 3, 4), Quaternion(5, 6, 7, 8))
-        @test_deprecated DualQuaternion{Int}(Quaternion(1, 2, 3, 4), Quaternion(5, 6, 7, 8))
-        @test_deprecated DualQuaternion{Float64}(Quaternion(1, 2, 3, 4), Quaternion(5, 6, 7, 8))
+        @test_deprecated DualQuaternion{Int}(Quaternion(1, 2, 3, 4), Quaternion(5, 6, 7, 8), false)
+        @test_deprecated DualQuaternion{Float64}(Quaternion(1, 2, 3, 4), Quaternion(5, 6, 7, 8), false)
     end
 
     @testset "convert" begin

--- a/test/DualQuaternion.jl
+++ b/test/DualQuaternion.jl
@@ -111,6 +111,12 @@ end
             DualQuaternion(Quaternion(1.0, 2, 3, 4), Quaternion(1, 2, 3, 4))
     end
 
+    @testset "deprecated warning" begin
+        @test_deprecated DualQuaternion(Quaternion(1, 2, 3, 4), Quaternion(5, 6, 7, 8))
+        @test_deprecated DualQuaternion{Int}(Quaternion(1, 2, 3, 4), Quaternion(5, 6, 7, 8))
+        @test_deprecated DualQuaternion{Float64}(Quaternion(1, 2, 3, 4), Quaternion(5, 6, 7, 8))
+    end
+
     @testset "convert" begin
         @test convert(DualQuaternion{Float64}, 1) === DualQuaternion(1.0)
         @test convert(DualQuaternion{Float64}, DualNumbers.Dual(1, 2)) ===


### PR DESCRIPTION
I think it would be better to add deprecated message for `DualQuaternion` before merging #92.