### PR TITLE
update `quat(::Array)` to return `Array{<:Quaternion}`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Quaternions"
 uuid = "94ee1d12-ae83-5a48-8b1c-48b8ff168ae0"
-version = "0.7.0-DEV"
+version = "0.7.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/Quaternion.jl
+++ b/src/Quaternion.jl
@@ -23,14 +23,6 @@ Quaternion{T}(x::Real) where {T<:Real} = Quaternion(convert(T, x))
 Quaternion{T}(q::Quaternion) where {T<:Real} = Quaternion{T}(q.s, q.v1, q.v2, q.v3)
 Quaternion(s::Real, v1::Real, v2::Real, v3::Real) = Quaternion(promote(s, v1, v2, v3)...)
 Quaternion(x::Real) = Quaternion(x, zero(x), zero(x), zero(x))
-function Quaternion(s::Real, a::AbstractVector)
-    Base.depwarn("`Quaternion(s::Real, a::AbstractVector)` is deprecated and will be removed in the next breaking release (v0.7.0). Please use `Quaternion(s, a[1], a[2], a[3])` instead.", :Quaternion)
-    Quaternion(s, a[1], a[2], a[3])
-end
-function Quaternion(a::AbstractVector)
-    Base.depwarn("`Quaternion(a::AbstractVector)` is deprecated and will be removed in the next breaking release (v0.7.0). Please use `Quaternion(0, a[1], a[2], a[3])` instead.", :Quaternion)
-    Quaternion(0, a[1], a[2], a[3])
-end
 
 Base.promote_rule(::Type{Quaternion{T}}, ::Type{S}) where {T <: Real, S <: Real} = Quaternion{promote_type(T, S)}
 Base.promote_rule(::Type{Quaternion{T}}, ::Type{Quaternion{S}}) where {T <: Real, S <: Real} = Quaternion{promote_type(T, S)}

--- a/src/Quaternion.jl
+++ b/src/Quaternion.jl
@@ -51,7 +51,6 @@ quat
 
 quat(p, v1, v2, v3) = Quaternion(p, v1, v2, v3)
 quat(x) = Quaternion(x)
-quat(s, a) = Quaternion(s, a)
 function quat(A::AbstractArray{T}) where T
     if !isconcretetype(T)
         error("`quat` not defined on abstractly-typed arrays; please convert to a more specific type")

--- a/src/Quaternion.jl
+++ b/src/Quaternion.jl
@@ -66,6 +66,23 @@ Quaternion{Int64}(0, 1, 2, 3)
 """
 quat
 
+"""
+    quat(r, [i, j, k])
+
+Convert real numbers or arrays to quaternion. `i, j, k` defaults to zero.
+
+# Examples
+```jldoctest
+julia> quat(7)
+Quaternion{Int64}(7, 0, 0, 0, false)
+
+julia> quat([1, 2, 3])
+3-element Vector{Quaternion{Int64}}:
+  Quaternion{Int64}(1, 0, 0, 0, true)
+ Quaternion{Int64}(2, 0, 0, 0, false)
+ Quaternion{Int64}(3, 0, 0, 0, false)
+```
+"""
 quat(p, v1, v2, v3) = Quaternion(p, v1, v2, v3)
 quat(x) = Quaternion(x)
 quat(s, a) = Quaternion(s, a)

--- a/src/Quaternion.jl
+++ b/src/Quaternion.jl
@@ -40,8 +40,11 @@ Quaternion{Int64}(7, 0, 0, 0)
 julia> quat(1.0, 2, 3, 4)
 QuaternionF64(1.0, 2.0, 3.0, 4.0)
 
-julia> quat([1, 2, 3])  # This output will be changed in the next breaking release for consistency. (#94)
-Quaternion{Int64}(0, 1, 2, 3)
+julia> quat([1, 2, 3])
+3-element Vector{Quaternion{Int64}}:
+ Quaternion{Int64}(1, 0, 0, 0)
+ Quaternion{Int64}(2, 0, 0, 0)
+ Quaternion{Int64}(3, 0, 0, 0)
 ```
 """
 quat

--- a/src/Quaternion.jl
+++ b/src/Quaternion.jl
@@ -49,23 +49,6 @@ julia> quat([1, 2, 3])
 """
 quat
 
-"""
-    quat(r, [i, j, k])
-
-Convert real numbers or arrays to quaternion. `i, j, k` defaults to zero.
-
-# Examples
-```jldoctest
-julia> quat(7)
-Quaternion{Int64}(7, 0, 0, 0)
-
-julia> quat([1, 2, 3])
-3-element Vector{Quaternion{Int64}}:
- Quaternion{Int64}(1, 0, 0, 0)
- Quaternion{Int64}(2, 0, 0, 0)
- Quaternion{Int64}(3, 0, 0, 0)
-```
-"""
 quat(p, v1, v2, v3) = Quaternion(p, v1, v2, v3)
 quat(x) = Quaternion(x)
 quat(s, a) = Quaternion(s, a)

--- a/src/Quaternion.jl
+++ b/src/Quaternion.jl
@@ -86,6 +86,12 @@ julia> quat([1, 2, 3])
 quat(p, v1, v2, v3) = Quaternion(p, v1, v2, v3)
 quat(x) = Quaternion(x)
 quat(s, a) = Quaternion(s, a)
+function quat(A::AbstractArray{T}) where T
+    if !isconcretetype(T)
+        error("`quat` not defined on abstractly-typed arrays; please convert to a more specific type")
+    end
+    convert(AbstractArray{typeof(quat(zero(T)))}, A)
+end
 
 """
     real(T::Type{<:Quaternion})

--- a/src/Quaternion.jl
+++ b/src/Quaternion.jl
@@ -54,13 +54,13 @@ Convert real numbers or arrays to quaternion. `i, j, k` defaults to zero.
 # Examples
 ```jldoctest
 julia> quat(7)
-Quaternion{Int64}(7, 0, 0, 0, false)
+Quaternion{Int64}(7, 0, 0, 0)
 
 julia> quat([1, 2, 3])
 3-element Vector{Quaternion{Int64}}:
-  Quaternion{Int64}(1, 0, 0, 0, true)
- Quaternion{Int64}(2, 0, 0, 0, false)
- Quaternion{Int64}(3, 0, 0, 0, false)
+ Quaternion{Int64}(1, 0, 0, 0)
+ Quaternion{Int64}(2, 0, 0, 0)
+ Quaternion{Int64}(3, 0, 0, 0)
 ```
 """
 quat(p, v1, v2, v3) = Quaternion(p, v1, v2, v3)

--- a/test/Quaternion.jl
+++ b/test/Quaternion.jl
@@ -85,6 +85,7 @@ end
         @test quat(1, 2, 3, 4) === Quaternion(1, 2, 3, 4)
         @test quat(Quaternion(1, 2, 3, 4)) === Quaternion(1, 2, 3, 4)
         @test quat([2, 3, 4]) == Quaternion{Int}[2, 3, 4]
+        @test_throws ErrorException quat(Real[1,2,3])
     end
 
     @testset "random generation" begin

--- a/test/Quaternion.jl
+++ b/test/Quaternion.jl
@@ -49,12 +49,6 @@ end
                 @test @inferred(Quaternion(q)) === q
             end
         end
-        @testset "from vector" begin
-            s = randn()
-            v = randn(3)
-            @test @inferred(Quaternion(s, v)) === Quaternion(s, v...)
-            @test @inferred(Quaternion(v)) === Quaternion(0, v)
-        end
     end
 
     @testset "==" begin
@@ -90,9 +84,7 @@ end
         @test quat(1) === Quaternion(1)
         @test quat(1, 2, 3, 4) === Quaternion(1, 2, 3, 4)
         @test quat(Quaternion(1, 2, 3, 4)) === Quaternion(1, 2, 3, 4)
-        @test quat(1, [2, 3, 4]) === Quaternion(1, 2, 3, 4)
-        @test quat([2, 3, 4]) === Quaternion(0, 2, 3, 4)
-        @test_deprecated quat([2, 3, 4])
+        @test quat([2, 3, 4]) == Quaternion{Int}[2, 3, 4]
     end
 
     @testset "random generation" begin


### PR DESCRIPTION
This PR fixes #94.
Note that this PR is considered as a breaking change.

https://github.com/JuliaGeometry/Quaternions.jl/blob/0be4cdd881872e14b480bdb69326f188f4b40236/test/Quaternion.jl#L112-L113
