### PR TITLE
Add deprecated warning to `Octonion`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Quaternions"
 uuid = "94ee1d12-ae83-5a48-8b1c-48b8ff168ae0"
-version = "0.5.6"
+version = "0.5.7"
 
 [deps]
 DualNumbers = "fa6b7ba4-c1ee-5f82-b5fc-ecf0adba8f74"

--- a/README.md
+++ b/README.md
@@ -64,47 +64,5 @@ Implemented functions are:
     rand
     randn
 
-[Dual quaternions](http://en.wikipedia.org/wiki/Dual_quaternion) are an extension, combining quaternions with
-[dual numbers](https://github.com/scidom/DualNumbers.jl).
-On top of just orientation, they can represent all rigid transformations.
-
-There are two conjugation concepts here
-
-    conj  (quaternion conjugation)
-    dconj (dual conjugation)
-
-further implemented here:
-
-    Q0  (the 'real' quaternion)
-    Qe  ( the 'dual' part)
-    +-*/^
-    abs
-    abs2
-    normalize
-    normalizea
-    angleaxis
-    angle
-    axis
-    exp
-    log
-    sqrt
-    rand
-
-[Octonions](http://en.wikipedia.org/wiki/Octonion) form the logical next step on the Complex-Quaternion path.
-They play a role, for instance, in the mathematical foundation of String theory.
-
-    +-*/^
-    real
-    imag_part  (tuple)
-    conj
-    abs
-    abs2
-    exp
-    log
-    normalize
-    normalizea  (return normalized octonion and absolute value as a tuple)
-    exp
-    log
-    sqrt
-    rand
-    randn
+Currently, this package supports `DualQuaternion` and `Octonion` types, but these will be removed in the next breaking release.
+See https://github.com/JuliaGeometry/Quaternions.jl/issues/90 and https://github.com/JuliaGeometry/Quaternions.jl/pull/92 for more information.

--- a/src/Octonion.jl
+++ b/src/Octonion.jl
@@ -8,6 +8,13 @@ struct Octonion{T<:Real} <: Number
   v6::T
   v7::T
   norm::Bool
+  function Octonion{T}(s,v1,v2,v3,v4,v5,v6,v7,norm) where T <: Real
+    Base.depwarn("`Octonion` is deprecated and will be removed in the next breaking release. Use Octonions.jl package instead.", :Octonion)
+    return new{T}(s,v1,v2,v3,v4,v5,v6,v7,norm)
+  end
+end
+function Octonion(s::T,v1::T,v2::T,v3::T,v4::T,v5::T,v6::T,v7::T,norm::Bool) where T <: Real
+  return Octonion{T}(s,v1,v2,v3,v4,v5,v6,v7,norm)
 end
 
 Octonion{T}(x::Real) where {T<:Real} = Octonion(convert(T, x))

--- a/test/Octonion.jl
+++ b/test/Octonion.jl
@@ -77,6 +77,12 @@ using Test
             Octonion(1, 0, 0, 0, 0, 0, 0, 0, true) # test that .norm field does not affect equality
     end
 
+    @testset "deprecated warning" begin
+        @test_deprecated Octonion(1, 2, 3, 4, 5, 6, 7, 8)
+        @test_deprecated Octonion{Int}(1, 2, 3, 4, 5, 6, 7, 8, false)
+        @test_deprecated Octonion{Float64}(1, 2, 3, 4, 5, 6, 7, 8, false)
+    end
+
     @testset "convert" begin
         @test convert(Octonion{Float64}, 1) === Octonion(1.0)
         @test convert(Octonion{Float64}, Complex(1, 2)) ===


### PR DESCRIPTION
This PR adds a deprecated warning to `Octonion` See discussions on https://github.com/JuliaGeometry/Quaternions.jl/issues/90 for more information.