### PR TITLE
Remove deprecated `imag` and `linpol`

### DIFF
--- a/src/Quaternion.jl
+++ b/src/Quaternion.jl
@@ -32,7 +32,6 @@ quat(s, a) = Quaternion(s, a)
 real(::Type{Quaternion{T}}) where {T} = T
 real(q::Quaternion) = q.s
 imag_part(q::Quaternion) = (q.v1, q.v2, q.v3)
-@deprecate imag(q::Quaternion) collect(imag_part(q)) false
 
 (/)(q::Quaternion, x::Real) = Quaternion(q.s / x, q.v1 / x, q.v2 / x, q.v3 / x)
 (*)(q::Quaternion, x::Real) = Quaternion(q.s * x, q.v1 * x, q.v2 * x, q.v3 * x)
@@ -357,8 +356,6 @@ function slerp(qa::Quaternion{Ta}, qb::Quaternion{Tb}, t::T) where {Ta, Tb, T}
     S = promote_type(Ta,Tb,T)
     return slerp(Quaternion{S}(qa),Quaternion{S}(qb),S(t))
 end
-
-Base.@deprecate linpol(p::Quaternion, q::Quaternion, t::Real) slerp(p, q, t)
 
 function sylvester(a::Quaternion{T}, b::Quaternion{T}, c::Quaternion{T}) where {T<:Real}
     isreal(a) && return sylvester(real(a), b, c)

--- a/test/Quaternion.jl
+++ b/test/Quaternion.jl
@@ -591,7 +591,7 @@ Base.:(/)(a::MyReal, b::Real) = a.val / b
             end
         end
 
-        @testset "slerp/linpol" begin
+        @testset "slerp" begin
             @testset "q1=1" begin
                 a = quat(1, 0, 0, 0.0, true)
                 b = quat(0, 0, 0, 1.0, true)
@@ -616,9 +616,6 @@ Base.:(/)(a::MyReal, b::Real) = a.val / b
                     @test slerp(q1, q2, 0.5) ≈ qrotation(ax, 0.5 * θ)
                     @test slerp(q1, q1, 0.5) ≈ q1
                     @test slerp(q1, qsmall, 0.5) ≈ sign((q1 + qsmall) / 2)
-                    @test linpol(q1, q2, 0.5) ≈ qrotation(ax, 0.5 * θ)
-                    @test linpol(q1, q1, 0.5) ≈ q1
-                    @test linpol(q1, qsmall, 0.5) ≈ sign((q1 + qsmall) / 2)
                 end
             end
 
@@ -628,7 +625,6 @@ Base.:(/)(a::MyReal, b::Real) = a.val / b
                     ⊗(s, t) = s * t * inv(s)
                     t = rand()
                     @test q ⊗ slerp(q1, q2, t) ≈ slerp(q ⊗ q1, q ⊗ q2, t)
-                    @test q ⊗ linpol(q1, q2, t) ≈ linpol(q ⊗ q1, q ⊗ q2, t)
                 end
             end
 

--- a/test/Quaternion.jl
+++ b/test/Quaternion.jl
@@ -178,7 +178,6 @@ Base.:(/)(a::MyReal, b::Real) = a.val / b
         qnorm = normalize(q)
         @test real(q) === q.s
         @test_throws MethodError imag(q)
-        @test @test_deprecated(Quaternions.imag(q)) == [q.v1, q.v2, q.v3]
         @test imag_part(q) === (q.v1, q.v2, q.v3)
         @test conj(q) === Quaternion(q.s, -q.v1, -q.v2, -q.v3, q.norm)
         @test conj(qnorm) === Quaternion(qnorm.s, -qnorm.v1, -qnorm.v2, -qnorm.v3, true)
@@ -644,10 +643,6 @@ Base.:(/)(a::MyReal, b::Real) = a.val / b
             @testset "DomainError" begin
                 @test_throws DomainError slerp(quat(1),quat(0),1)
                 @test_throws DomainError slerp(quat(0),quat(1),0)
-            end
-
-            @testset "Deprecated warning" begin
-                @test_deprecated linpol(quat(1),quat(1),0)
             end
 
             @testset "Normalizing input quaternions" begin


### PR DESCRIPTION
This PR removes deprecated `imag` and `linpol`.