### PR TITLE
Split `ci.yml` into `ci.yml` and `docs.yml`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,13 +34,3 @@ jobs:
       - uses: codecov/codecov-action@v2
         with:
           file: lcov.info
-  docs:
-    name: Documentation
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-docdeploy@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,17 @@
+name: Documentation
+on:
+  push:
+    branches: [master]
+    tags: [v*]
+  pull_request:
+jobs:
+  docs:
+    name: Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-docdeploy@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
It seems we don't need the scheduled document deployment. (x-ref: https://github.com/JuliaGeometry/Quaternions.jl/pull/71#discussion_r858811712)

(I see this kind of scheduled feed on my GitHub top page every day, and this is a little boring.)

![image](https://user-images.githubusercontent.com/7488140/192085893-885d0a5c-9d4f-44fa-8f92-8c7170e69b42.png)
