### PR TITLE
Add Aqua.jl in test

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,10 +7,12 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
+Aqua = "0.5"
 julia = "1"
 
 [extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Test", "Aqua"]

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A Julia implementation of quaternions.
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://JuliaGeometry.github.io/Quaternions.jl/dev)
 [![Build Status](https://github.com/JuliaGeometry/Quaternions.jl/workflows/CI/badge.svg)](https://github.com/JuliaGeometry/Quaternions.jl/actions?query=workflow%3ACI+branch%3Amaster)
 [![codecov](https://codecov.io/gh/JuliaGeometry/Quaternions.jl/branch/master/graph/badge.svg?token=dJBiR91dCD)](https://codecov.io/gh/JuliaGeometry/Quaternions.jl)
+[![Aqua QA](https://raw.githubusercontent.com/JuliaTesting/Aqua.jl/master/badge.svg)](https://github.com/JuliaTesting/Aqua.jl)
 
 [Quaternions](http://en.wikipedia.org/wiki/Quaternion) are best known for their suitability
 as representations of 3D rotational orientation. They can also be viewed as an extension of complex numbers.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,8 @@
 using Test
 using Quaternions
+using Aqua
+
+Aqua.test_all(Quaternions)
 
 include("helpers.jl")
 include("Quaternion.jl")


### PR DESCRIPTION
This PR adds [Aqua.jl](https://github.com/JuliaTesting/Aqua.jl) to ensure the project quality.
With Aqua.jl, we can detect invalid exports (e.g. https://github.com/JuliaGeometry/Quaternions.jl/pull/100#discussion_r988706344) in the test.