### PR TITLE
Rename master branch to main in repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   push:
-    branches: [master]
+    branches: [main]
     tags: [v*]
   pull_request:
   schedule:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,7 +1,7 @@
 name: Documentation
 on:
   push:
-    branches: [master]
+    branches: [main]
     tags: [v*]
   pull_request:
 jobs:

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ A Julia implementation of quaternions.
 
 [![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://JuliaGeometry.github.io/Quaternions.jl/stable)
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://JuliaGeometry.github.io/Quaternions.jl/dev)
-[![Build Status](https://github.com/JuliaGeometry/Quaternions.jl/workflows/CI/badge.svg)](https://github.com/JuliaGeometry/Quaternions.jl/actions?query=workflow%3ACI+branch%3Amaster)
-[![codecov](https://codecov.io/gh/JuliaGeometry/Quaternions.jl/branch/master/graph/badge.svg?token=dJBiR91dCD)](https://codecov.io/gh/JuliaGeometry/Quaternions.jl)
+[![Build Status](https://github.com/JuliaGeometry/Quaternions.jl/workflows/CI/badge.svg)](https://github.com/JuliaGeometry/Quaternions.jl/actions?query=workflow%3ACI+branch%3Amain)
+[![codecov](https://codecov.io/gh/JuliaGeometry/Quaternions.jl/branch/main/graph/badge.svg?token=dJBiR91dCD)](https://codecov.io/gh/JuliaGeometry/Quaternions.jl)
 [![Aqua QA](https://raw.githubusercontent.com/JuliaTesting/Aqua.jl/master/badge.svg)](https://github.com/JuliaTesting/Aqua.jl)
 
 [Quaternions](http://en.wikipedia.org/wiki/Quaternion) are best known for their suitability

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -20,5 +20,5 @@ makedocs(;
 )
 
 deploydocs(;
-    repo="github.com/JuliaGeometry/Quaternions.jl",
+    repo="github.com/JuliaGeometry/Quaternions.jl", devbranch="main",
 )

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -6,7 +6,7 @@ A Julia package implementing [quaternions](https://en.wikipedia.org/wiki/Quatern
     The documentation is still work in progress.
     For more information, see also
     * [README in the repository](https://github.com/JuliaGeometry/Quaternions.jl)
-    * [Tests in the repository](https://github.com/JuliaGeometry/Quaternions.jl/tree/master/test)
+    * [Tests in the repository](https://github.com/JuliaGeometry/Quaternions.jl/tree/main/test)
     Feel free to [open pull requests](https://github.com/JuliaGeometry/Quaternions.jl/pulls) and improve this document!
 
 ## Installation


### PR DESCRIPTION
The master branch has already been renamed to main in the repository. This PR updates all references in the repo accordingly.