### PR TITLE
Fix randomly failing log test on nightly

### DIFF
--- a/test/Quaternion.jl
+++ b/test/Quaternion.jl
@@ -379,10 +379,10 @@ end
             @testset "log" begin
                 @test log(zero(QuaternionF64)) === Quaternion(-Inf, 0, 0, 0)
                 @test log(one(QuaternionF64)) === Quaternion(0.0, 0, 0, 0)
-                @test log(-one(QuaternionF64)) == Quaternion(0.0, π, 0, 0)
+                @test log(-one(QuaternionF64)) ≈ Quaternion(0.0, π, 0, 0)
                 x = rand()
-                @test log(quat(x)) == quat(log(x))
-                @test log(quat(-x)) == Quaternion(reim(log(complex(-x)))..., 0, 0)
+                @test log(quat(x)) ≈ quat(log(x))
+                @test log(quat(-x)) ≈ Quaternion(reim(log(complex(-x)))..., 0, 0)
             end
 
             @testset "exp" begin

--- a/test/Quaternion.jl
+++ b/test/Quaternion.jl
@@ -379,7 +379,7 @@ end
             @testset "log" begin
                 @test log(zero(QuaternionF64)) === Quaternion(-Inf, 0, 0, 0)
                 @test log(one(QuaternionF64)) === Quaternion(0.0, 0, 0, 0)
-                @test log(-one(QuaternionF64)) ≈ Quaternion(0.0, π, 0, 0)
+                @test log(-one(QuaternionF64)) ≈ Quaternion(0, π, 0, 0)
                 x = rand()
                 @test log(quat(x)) ≈ quat(log(x))
                 @test log(quat(-x)) ≈ Quaternion(reim(log(complex(-x)))..., 0, 0)


### PR DESCRIPTION
The new tests for `log` added in #115 randomly fail on nightly due to an equality test. Here an approximate equality test is fine, so this PR uses that instead.