### PR TITLE
Cleanup `src/Quaternions.jl`

### DIFF
--- a/src/Quaternions.jl
+++ b/src/Quaternions.jl
@@ -1,5 +1,3 @@
-__precompile__()
-
 module Quaternions
 
   using Random

--- a/src/Quaternions.jl
+++ b/src/Quaternions.jl
@@ -1,17 +1,16 @@
 module Quaternions
 
-  using Random
-  using LinearAlgebra
+using Random
+using LinearAlgebra
 
-  include("Quaternion.jl")
+include("Quaternion.jl")
 
-  export Quaternion,
-    QuaternionF16,
-    QuaternionF32,
-    QuaternionF64
-  export quat
-  export imag_part
-  export quatrand
-  export nquatrand
-  export slerp
-end
+export Quaternion
+export QuaternionF16, QuaternionF32, QuaternionF64
+export quat
+export imag_part
+export quatrand
+export nquatrand
+export slerp
+
+end # module


### PR DESCRIPTION
* Remove `__precompile__()`
  * This function call is not required in the recent Julia package practices.
  * See `help?> __precompile__()` for more information.
* Remove indents
  * Many packages do not have indents inside the main module block, and the current two spaces are inconsistent.