### PR TITLE
fix typo in docstring

### DIFF
--- a/src/Quaternion.jl
+++ b/src/Quaternion.jl
@@ -198,7 +198,7 @@ and ``a \\ge 0`` is the magnitude of the imaginary part of ``q``,
 ```math
 f(q) = \\Re(f(z)) + \\Im(f(z)) u,
 ```
-is the extension of `f` to the quaternions, where ``z = a + s i`` is a complex analog to
+is the extension of `f` to the quaternions, where ``z = s + a i`` is a complex analog to
 ``q``.
 
 See Theorem 5 of [^Sudbery1970] for details.


### PR DESCRIPTION
This seems to be a typo in the documentation (the code is correct).

From Sudbury:
<img width="600" alt="image" src="https://user-images.githubusercontent.com/2913679/206820439-47edbeae-c683-428a-a7bd-d80a06536376.png">
