### PR TITLE
Implement more base methods

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Quaternions"
 uuid = "94ee1d12-ae83-5a48-8b1c-48b8ff168ae0"
-version = "0.7.0"
+version = "0.7.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -19,6 +19,10 @@ imag_part
 ```
 
 ```@docs
+round(::Quaternion)
+```
+
+```@docs
 conj
 ```
 

--- a/test/Quaternion.jl
+++ b/test/Quaternion.jl
@@ -624,9 +624,8 @@ end
         @test round(q, RoundUp; digits=1) == q
         @test round(q, RoundUp, RoundToZero) == quat(2.0, 2.0, -3.0, 2.0)
         @test round(q, RoundUp, RoundToZero; digits=1) == q
-        @test round(q, RoundUp, RoundDown, RoundNearestTiesAway, RoundToZero) ==
-            quat(2.0, 2.0, -4.0, 2.0)
-        @test round(q, RoundUp, RoundDown, RoundNearestTiesAway, RoundToZero; digits=1) ==
-            q
+        rmodes = (RoundUp, RoundDown, RoundNearestTiesAway, RoundToZero)
+        @test round(q, rmodes...) == quat(2.0, 2.0, -4.0, 2.0)
+        @test round(q, rmodes...; digits=1) == q
     end
 end

--- a/test/Quaternion.jl
+++ b/test/Quaternion.jl
@@ -227,6 +227,14 @@ end
         @test isnan(Quaternion(1, 2, 3, NaN))
     end
 
+    @testset "isinteger" begin
+        @test isinteger(quat(3))
+        @test isinteger(quat(4.0))
+        @test !isinteger(quat(4.1))
+        @test !isinteger(quat(3, 1, 2, 3))
+        @test !isinteger(quat(4, 0, 1, 0))
+    end
+
     @testset "*" begin
         # verify basic correctness
         q1 = Quaternion(1,0,0,0)
@@ -570,5 +578,55 @@ end
             @test_throws DivideError sylvester(null, null, null)
             @test_throws DivideError lyap(null, null)
         end
+    end
+
+    @testset "widen" begin
+        @test widen(Quaternion{Int}) === Quaternion{Int128}
+        @test widen(QuaternionF32) === QuaternionF64
+        @test widen(QuaternionF64) === Quaternion{BigFloat}
+        @test widen(quat(1, 2, 3, 4)) === Quaternion{Int128}(1, 2, 3, 4)
+        q = rand(QuaternionF32)
+        @test widen(q) == convert(QuaternionF64, q)
+        q = rand(QuaternionF64)
+        @test widen(q) == convert(Quaternion{BigFloat}, q)
+    end
+
+    @testset "flipsign" begin
+        q = rand(QuaternionF64)
+        @test flipsign(q, 2) == q
+        @test flipsign(q, -3) == -q
+    end
+
+    @testset "read/write" begin
+        @testset "$T" for T in (Int16, Float32, Float64)
+            io = IOBuffer(; read=true, write=true)
+            q = rand(Quaternion{T})
+            write(io, q)
+            seek(io, 0)
+            q2 = read(io, Quaternion{T})
+            @test q == q2
+        end
+    end
+
+    @testset "big" begin
+        @test big(Quaternion{Int}) === Quaternion{BigInt}
+        @test big(QuaternionF64) === Quaternion{BigFloat}
+        @test big(quat(1, 2, 3, 4)) == Quaternion{BigInt}(1, 2, 3, 4)
+        q = rand(QuaternionF64)
+        @test big(q) == convert(Quaternion{BigFloat}, q)
+    end
+
+    @testset "round" begin
+        q = quat(1.1, 2.5, -3.5, 2.3)
+        @test round(q) == quat(1.0, 2.0, -4.0, 2.0)
+        @test round(q; digits=1) == q
+        @test round(q, RoundUp) == quat(2.0, 3.0, -3.0, 3.0)
+        @test round(q, RoundUp; digits=1) == q
+        @test round(q, RoundUp, RoundToZero) == quat(2.0, 2.0, -3.0, 2.0)
+        @test round(q, RoundUp, RoundToZero; digits=1) == q
+        @test round(q, RoundUp, RoundDown, RoundNearestTiesAway, RoundToZero) ==
+            quat(2.0, 2.0, -4.0, 2.0)
+        @test round(q, RoundUp, RoundDown, RoundNearestTiesAway, RoundToZero; digits=1) ==
+            q
     end
 end


### PR DESCRIPTION
I went through https://github.com/JuliaLang/julia/blob/v1.8.3/base/complex.jl and implemented here for `Quaternion` all overloads that are there implemented for `Complex`. All of these methods resulted in a `MethodError` before this PR, so this is a non-breaking change.

The one overload I did not implement is `hash`, which I would need to take some more time to understand.