### PR TITLE
Make abs and abs_imag resistant to under/overflow

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Quaternions"
 uuid = "94ee1d12-ae83-5a48-8b1c-48b8ff168ae0"
-version = "0.7.1"
+version = "0.7.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/Quaternion.jl
+++ b/src/Quaternion.jl
@@ -136,9 +136,15 @@ Quaternion{Int64}(1, -2, -3, -4)
 ```
 """
 Base.conj(q::Quaternion) = Quaternion(q.s, -q.v1, -q.v2, -q.v3)
-Base.abs(q::Quaternion) = sqrt(abs2(q))
+@static if VERSION < v"1.9-alpha1"
+    # hypot very slow for more than 3 arguments for older Julia versions
+    # https://github.com/JuliaLang/julia/issues/44336
+    Base.abs(q::Quaternion) = sqrt(abs2(q))
+else
+    Base.abs(q::Quaternion) = hypot(real(q), imag_part(q)...)
+end
 Base.float(q::Quaternion{T}) where T = convert(Quaternion{float(T)}, q)
-abs_imag(q::Quaternion) = sqrt(q.v2 * q.v2 + (q.v1 * q.v1 + q.v3 * q.v3)) # ordered to match abs2
+abs_imag(q::Quaternion) = hypot(imag_part(q)...)
 Base.abs2(q::Quaternion) = (q.s * q.s + q.v2 * q.v2) + (q.v1 * q.v1 + q.v3 * q.v3)
 Base.inv(q::Quaternion) = conj(q) / abs2(q)
 

--- a/test/Quaternion.jl
+++ b/test/Quaternion.jl
@@ -153,7 +153,7 @@ end
         @test conj(conj(q)) === q
         @test conj(conj(qnorm)) === qnorm
         @test float(Quaternion(1, 2, 3, 4)) === float(Quaternion(1.0, 2.0, 3.0, 4.0))
-        @test Quaternions.abs_imag(q) == abs(Quaternion(0, q.v1, q.v2, q.v3))
+        @test Quaternions.abs_imag(q) ≈ abs(Quaternion(0, q.v1, q.v2, q.v3))
     end
 
     @testset "algebraic properties" begin

--- a/test/Quaternion.jl
+++ b/test/Quaternion.jl
@@ -156,6 +156,14 @@ end
         @test Quaternions.abs_imag(q) ≈ abs(Quaternion(0, q.v1, q.v2, q.v3))
     end
 
+    @testset "abs/abs_imag don't over/underflow" begin
+        for x in [1e-300, 1e-300]
+            q = quat(x, x, x, x)
+            @test Quaternions.abs_imag(q) == sqrt(3) * x
+            @test abs(q) == 2x broken=(VERSION < v"1.9-alpha1")
+        end
+    end
+
     @testset "algebraic properties" begin
         for _ in 1:100, T in (Float32, Float64, Int32, Int64)
             if T <: Integer


### PR DESCRIPTION
Currently `abs` and `abs_imag` effectively use `abs2` under the hood. For very small numbers, this causes underflow, and for very large numbers, this causes overflow. In base. `abs(z::Complex)` uses `hypot`, which takes care to avoid under/overflow. This PR uses `hypot` in `abs` and `abs_imag`.

Before Julia 1.9, `hypot` for more than 3 args was unbearably slow (https://github.com/JuliaLang/julia/issues/44336), so `abs` is only changed for 1.9 and later.

There is a performance cost. On v1.9-alpha1:
```julia
julia> using Quaternions, BenchmarkTools

julia> q = randn(QuaternionF64);

julia> q = quat(1.3, 5.6, -3.3, 0.9);

julia> q2 = quat(fill(1e-300, 4)...);
```

On main
```julia
julia> @btime abs($q);
  1.927 ns (0 allocations: 0 bytes)

julia> @btime $(Quaternions.abs_imag)($q);
  1.922 ns (0 allocations: 0 bytes)

julia> @btime abs($q2);
  1.922 ns (0 allocations: 0 bytes)

julia> @btime $(Quaternions.abs_imag)($q2);
  1.922 ns (0 allocations: 0 bytes)
```

this PR
```julia
julia> @btime abs($q);
  8.471 ns (0 allocations: 0 bytes)

julia> @btime $(Quaternions.abs_imag)($q);
  25.249 ns (0 allocations: 0 bytes)

julia> @btime abs($q2);
  8.859 ns (0 allocations: 0 bytes)

julia> @btime $(Quaternions.abs_imag)($q2);
  25.240 ns (0 allocations: 0 bytes)
```

I have no idea why after this PR `abs_imag` is more expensive than `abs`, when it does more operations.

```julia
julia> @code_typed Quaternions.abs(q)
CodeInfo(
1 ─ %1 = Base.getfield(q, :s)::Float64
│   %2 = Base.getfield(q, :v1)::Float64
│   %3 = Base.getfield(q, :v2)::Float64
│   %4 = Base.getfield(q, :v3)::Float64
│   %5 = Core.tuple(%1, %2, %3, %4)::NTuple{4, Float64}
│   %6 = invoke Base.Math._hypot(%5::NTuple{4, Float64})::Float64
└──      return %6
) => Float64

julia> @code_typed Quaternions.abs_imag(q)
CodeInfo(
1 ─ %1 = Base.getfield(q, :v1)::Float64
│   %2 = Base.getfield(q, :v2)::Float64
│   %3 = Base.getfield(q, :v3)::Float64
│   %4 = Core.tuple(%1, %2, %3)::Tuple{Float64, Float64, Float64}
│   %5 = invoke Base.Math._hypot(%4::Tuple{Float64, Float64, Float64})::Float64
└──      return %5
) => Float64
```