### PR TITLE
Deprecate `quatrand` and `nquatrand`

### DIFF
--- a/src/Quaternion.jl
+++ b/src/Quaternion.jl
@@ -325,8 +325,8 @@ end
 
 Base.:^(q::Quaternion, w::Quaternion) = exp(w * log(q))
 
-quatrand(rng = Random.GLOBAL_RNG)  = quat(randn(rng), randn(rng), randn(rng), randn(rng))
-nquatrand(rng = Random.GLOBAL_RNG) = sign(quatrand(rng))
+Base.@deprecate quatrand(rng::AbstractRNG=Random.GLOBAL_RNG) randn(rng, QuaternionF64) * 2
+Base.@deprecate nquatrand(rng = Random.GLOBAL_RNG) sign(randn(rng, QuaternionF64))
 
 function Base.rand(rng::AbstractRNG, ::Random.SamplerType{Quaternion{T}}) where {T<:Real}
     Quaternion{T}(rand(rng, T), rand(rng, T), rand(rng, T), rand(rng, T))

--- a/src/Quaternion.jl
+++ b/src/Quaternion.jl
@@ -334,10 +334,10 @@ end
 
 function Base.randn(rng::AbstractRNG, ::Type{Quaternion{T}}) where {T<:AbstractFloat}
     Quaternion{T}(
-        randn(rng, T) * 1//2,
-        randn(rng, T) * 1//2,
-        randn(rng, T) * 1//2,
-        randn(rng, T) * 1//2,
+        randn(rng, T) / 2,
+        randn(rng, T) / 2,
+        randn(rng, T) / 2,
+        randn(rng, T) / 2,
     )
 end
 

--- a/src/Quaternions.jl
+++ b/src/Quaternions.jl
@@ -10,8 +10,6 @@ export Quaternion
 export QuaternionF16, QuaternionF32, QuaternionF64
 export quat
 export imag_part
-export quatrand
-export nquatrand
 export slerp
 
 end # module

--- a/test/Quaternion.jl
+++ b/test/Quaternion.jl
@@ -97,6 +97,7 @@ end
 
     @testset "random generation" begin
         @testset "quatrand" begin
+            @test_deprecated quatrand()
             rng = Random.MersenneTwister(42)
             q1 = quatrand(rng)
             @test q1 isa Quaternion
@@ -106,6 +107,7 @@ end
         end
 
         @testset "nquatrand" begin
+            @test_deprecated nquatrand()
             rng = Random.MersenneTwister(42)
             q1 = nquatrand(rng)
             @test q1 isa Quaternion


### PR DESCRIPTION
Related PR to https://github.com/JuliaGeometry/Octonions.jl/pull/19.