### PR TITLE
Update the version of Aqua

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RealDot = "c1ae055f-0cd5-4b69-90a6-9a35b1a98df9"
 
 [compat]
-Aqua = "0.5"
+Aqua = "0.6"
 RealDot = "0.1"
 julia = "1"
 


### PR DESCRIPTION
CompatHelper does not check the `[compat]` table of versions of indirect dependencies, so I checked it:smile:

x-ref: https://github.com/JuliaRegistries/CompatHelper.jl/issues/247