### PR TITLE
Add more methods to `quat`

### DIFF
--- a/src/Quaternion.jl
+++ b/src/Quaternion.jl
@@ -65,7 +65,7 @@ end
 """
     quat(T::Type)
 
-Return an appropriate type which can represent a value of type `T` as a quaternion.
+Return an appropriate type that can represent a value of type `T` as a quaternion.
 Equivalent to `typeof(quat(zero(T)))`.
 
 # Examples

--- a/src/Quaternion.jl
+++ b/src/Quaternion.jl
@@ -54,7 +54,7 @@ quat(s::Real) = Quaternion(s)
 quat(s::Real, v1::Real, v2::Real, v3::Real) = Quaternion(s, v1, v2, v3)
 
 ## Array operations on quaternions ##
-complex(A::AbstractArray{<:Complex}) = A
+quat(A::AbstractArray{<:Quaternion}) = A
 function quat(A::AbstractArray{T}) where T
     if !isconcretetype(T)
         error("`quat` not defined on abstractly-typed arrays; please convert to a more specific type")

--- a/src/Quaternion.jl
+++ b/src/Quaternion.jl
@@ -47,7 +47,7 @@ julia> quat([1, 2, 3])
  Quaternion{Int64}(3, 0, 0, 0)
 ```
 """
-function quat end
+quat
 
 quat(q::Quaternion) = q
 quat(s::Real) = Quaternion(s)

--- a/test/Quaternion.jl
+++ b/test/Quaternion.jl
@@ -97,6 +97,8 @@ end
 
         @test quat(Int) === Quaternion{Int}
         @test quat(Float32) === Quaternion{Float32}
+        @test quat(Quaternion{Int}) === Quaternion{Int}
+        @test quat(Quaternion{Float32}) === Quaternion{Float32}
 
         # Note that `quat(1,missing,0,0)` throws an error.
         # This is the same behavior as `complex(1,missing)`.

--- a/test/Quaternion.jl
+++ b/test/Quaternion.jl
@@ -93,6 +93,16 @@ end
         @test quat(Quaternion(1, 2, 3, 4)) === Quaternion(1, 2, 3, 4)
         @test quat([2, 3, 4]) == Quaternion{Int}[2, 3, 4]
         @test_throws ErrorException quat(Real[1,2,3])
+        @test quat(Quaternion[1,2]) == Quaternion[1,2]
+
+        @test quat(Int) === Quaternion{Int}
+        @test quat(Float32) === Quaternion{Float32}
+
+        # Note that `quat(1,missing,0,0)` throws an error.
+        # This is the same behavior as `complex(1,missing)`.
+        @test quat(missing) === missing
+        @test quat(Missing) === Missing
+        @test quat(Union{Missing, Int}) === Union{Missing, Quaternion{Int}}
     end
 
     @testset "random generation" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,9 @@ using Quaternions
 using Aqua
 using RealDot
 
-Aqua.test_all(Quaternions)
+# Avoid tests on unbound_args.
+# https://github.com/JuliaGeometry/Quaternions.jl/pull/132#discussion_r1383817950
+Aqua.test_all(Quaternions, unbound_args=false)
 
 include("helpers.jl")
 include("Quaternion.jl")


### PR DESCRIPTION
# Abstract
This PR adds more methods to `quat`.

**Before this PR**
```julia
julia> using Quaternions

julia> quat(missing)
ERROR: MethodError: no method matching Quaternion(::Missing)
```

**After this PR**
```julia
julia> using Quaternions

julia> quat(missing)
missing
```

This behavior is consistent with `Base.complex`.

```julia
julia> complex(missing)
missing
```

# How to find the methods to add
I have confirmed the methods with the `methods` function.
```julia
julia> using Quaternions

julia> methods(complex)
# 13 methods for generic function "complex" from Base:
  [1] complex(z::Complex)
     @ complex.jl:172
  [2] complex(x::Real)
     @ complex.jl:173
  [3] complex(x::Real, y::Real)
     @ complex.jl:174
  [4] complex(::Type{T}) where T<:Real
     @ complex.jl:191
  [5] complex(::Type{Complex{T}}) where T<:Real
     @ complex.jl:192
  [6] complex(S::SparseArrays.SparseMatrixCSC)
     @ SparseArrays ~/.julia/juliaup/julia-1.9.3+0.x64.linux.gnu/share/julia/stdlib/v1.9/SparseArrays/src/sparsematrix.jl:936
  [7] complex(x::SparseArrays.AbstractSparseVector{<:Complex})
     @ SparseArrays ~/.julia/juliaup/julia-1.9.3+0.x64.linux.gnu/share/julia/stdlib/v1.9/SparseArrays/src/sparsevector.jl:1083
  [8] complex(x::SparseArrays.AbstractSparseVector)
     @ SparseArrays ~/.julia/juliaup/julia-1.9.3+0.x64.linux.gnu/share/julia/stdlib/v1.9/SparseArrays/src/sparsevector.jl:1084
  [9] complex(A::AbstractArray{<:Complex})
     @ complex.jl:1117
 [10] complex(A::AbstractArray{T}) where T
     @ complex.jl:1119
 [11] complex(::Type{Missing})
     @ missing.jl:111
 [12] complex(::Type{Union{Missing, T}}) where T
     @ missing.jl:112
 [13] complex(::Missing)
     @ missing.jl:101

julia> methods(quat)
# 9 methods for generic function "quat" from Quaternions:
 [1] quat(q::Quaternion)
     @ ~/.julia/dev/Quaternions/src/Quaternion.jl:52
 [2] quat(s::Real)
     @ ~/.julia/dev/Quaternions/src/Quaternion.jl:53
 [3] quat(s::Real, v1::Real, v2::Real, v3::Real)
     @ ~/.julia/dev/Quaternions/src/Quaternion.jl:54
 [4] quat(A::AbstractArray{T}) where T
     @ ~/.julia/dev/Quaternions/src/Quaternion.jl:58
 [5] quat(::Type{T}) where T<:Real
     @ ~/.julia/dev/Quaternions/src/Quaternion.jl:80
 [6] quat(::Type{Quaternion{T}}) where T<:Real
     @ ~/.julia/dev/Quaternions/src/Quaternion.jl:81
 [7] quat(::Type{Missing})
     @ ~/.julia/dev/Quaternions/src/Quaternion.jl:85
 [8] quat(::Type{Union{Missing, T}}) where T
     @ ~/.julia/dev/Quaternions/src/Quaternion.jl:86
 [9] quat(::Missing)
     @ ~/.julia/dev/Quaternions/src/Quaternion.jl:83
```

Note that this PR does not contain methods with `SparseArrays` because there were some performance degressions.
```julia
julia> using BenchmarkTools, SparseArrays, Quaternions

julia> M = sprand(Float64, 16, 32, 0.5)
16×32 SparseMatrixCSC{Float64, Int64} with 261 stored entries:
⎡⣅⢶⡢⠫⠿⠢⢽⣃⠾⣠⣾⢕⠝⠅⠩⢗⎤
⎢⠃⢱⡜⣴⠓⣂⢼⡁⢴⣴⢘⡊⠯⡒⡚⣞⎥
⎢⣥⡕⠏⢯⠫⠲⠦⠓⢁⣂⢚⣹⣕⢺⢼⢎⎥
⎣⣜⡩⣛⢝⣄⢿⠈⠨⢴⢕⢒⡿⡡⣱⣑⡪⎦

julia> @benchmark quat(M)
BenchmarkTools.Trial: 10000 samples with 10 evaluations.
 Range (min … max):  1.300 μs … 208.680 μs  ┊ GC (min … max):  0.00% … 95.74%
 Time  (median):     1.831 μs               ┊ GC (median):     0.00%
 Time  (mean ± σ):   2.394 μs ±   7.297 μs  ┊ GC (mean ± σ):  13.67% ±  4.51%

   ▂▄▄▅▆▇██▇▆▆▆▅▄▃▁▁                       ▁▂▂▂ ▁             ▂
  ▆███████████████████▇▇▇▇▆▆▆▄▅▅▅▂▄▅▅▂▅▇▇██████████████▇▇█▇▆▆ █
  1.3 μs       Histogram: log(frequency) by time      4.88 μs <

 Memory estimate: 10.88 KiB, allocs estimate: 4.

julia> Quaternions.quat(S::SparseMatrixCSC) = SparseMatrixCSC(size(S, 1), size(S, 2), copy(SparseArrays.getcolptr(S)), copy(rowvals(S)), quat(copy(nonzeros(S))))

julia> @benchmark quat(M)
BenchmarkTools.Trial: 10000 samples with 10 evaluations.
 Range (min … max):  1.631 μs … 180.029 μs  ┊ GC (min … max):  0.00% … 94.98%
 Time  (median):     2.170 μs               ┊ GC (median):     0.00%
 Time  (mean ± σ):   2.681 μs ±   8.186 μs  ┊ GC (mean ± σ):  15.66% ±  5.05%

          ▃██▂                                                 
  ▁▂▂▂▂▃▄▇████▆▃▂▂▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▂
  1.63 μs         Histogram: frequency by time        4.81 μs <

 Memory estimate: 13.06 KiB, allocs estimate: 5.
```

The above definition `Quaternions.quat(S::SparseMatrixCSC)` is from:

https://github.com/JuliaSparse/SparseArrays.jl/blob/bd2bda8f45ed71374223068b0a0daa2b169071c9/src/sparsematrix.jl#L984