### PR TITLE
Update around `inv`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Quaternions"
 uuid = "94ee1d12-ae83-5a48-8b1c-48b8ff168ae0"
-version = "0.7.4"
+version = "0.7.5"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -27,6 +27,10 @@ conj
 ```
 
 ```@docs
+inv
+```
+
+```@docs
 sign
 ```
 

--- a/src/Quaternion.jl
+++ b/src/Quaternion.jl
@@ -158,6 +158,25 @@ function abs_imag(q::Quaternion)
     end
 end
 Base.abs2(q::Quaternion) = RealDot.realdot(q,q)
+
+"""
+    inv(q::Quaternion)
+
+Return the multiplicative inverse of `q::Quaternion`, such that `q*inv(q)` or `inv(q)*q`
+yields `one(q)` (the multiplicative identity) up to roundoff errors.
+
+# Examples
+```jldoctest
+julia> inv(quat(1))
+QuaternionF64(1.0, -0.0, -0.0, -0.0)
+
+julia> inv(quat(1, 2, 0, 0))
+QuaternionF64(0.2, -0.4, -0.0, -0.0)
+
+julia> inv(quat(2//3))
+Quaternion{Rational{Int64}}(3//2, 0//1, 0//1, 0//1)
+```
+"""
 function Base.inv(q::Quaternion)
     if isinf(q)
         return quat(

--- a/src/Quaternion.jl
+++ b/src/Quaternion.jl
@@ -250,6 +250,9 @@ function Base.:/(q::Quaternion{T}, w::Quaternion{T}) where T
     return (q * conj(p)) / RealDot.realdot(w, p)
 end
 
+Base.://(x::Quaternion, y::Real) = quat(real(x)//y, imag_part(x).//y...)
+Base.://(x::Number, y::Quaternion) = x*conj(y)//abs2(y)
+
 Base.:(==)(q::Quaternion, w::Quaternion) = (q.s == w.s) & (q.v1 == w.v1) & (q.v2 == w.v2) & (q.v3 == w.v3)
 function Base.isequal(q::Quaternion, w::Quaternion)
     isequal(q.s, w.s) & isequal(q.v1, w.v1) & isequal(q.v2, w.v2) & isequal(q.v3, w.v3)

--- a/test/Quaternion.jl
+++ b/test/Quaternion.jl
@@ -351,6 +351,15 @@ end
         end
     end
 
+    @testset "//" begin
+        q = quat(1,2,3,4)
+        r = quat(1,2,3,4//1)
+        @test q // 1 === r
+        @test isone(q // q)
+        @test quat(1,-2,0,0) // quat(2,1,0,0) === quat(0,-1//1,0,0)
+        @test inv(r) === (1//1)/q
+    end
+
     @testset "^" begin
         @testset "^(::Quaternion, ::Real)" begin
             for _ in 1:100


### PR DESCRIPTION
* Add docstring to `inv(::Quaternion)`
* Add methods to `Base.://`

**Before this PR**
```julia
julia> using Quaternions

julia> Quaternion(1,2,3,4) // Quaternion(5,6,7,8)
ERROR: MethodError: no method matching //(::Quaternion{Int64}, ::Quaternion{Int64})

Closest candidates are:
  //(::Number, ::Complex)
   @ Base rational.jl:79
  //(::AbstractArray, ::Number)
   @ Base rational.jl:82
```

**After this PR**
```julia
julia> using Quaternions

julia> Quaternion(1,2,3,4) // Quaternion(5,6,7,8)
Quaternion{Rational{Int64}}(35//87, 4//87, 0//1, 8//87)
```

This behavior is consistent with `//(::Complex, ::Complex)`
```julia
julia> complex(1,2) // complex(5,6)
17//61 + 4//61*im
```