### PR TITLE
Add `Base.hash(::Quaternion, ::UInt)`

### DIFF
--- a/src/Quaternion.jl
+++ b/src/Quaternion.jl
@@ -244,7 +244,7 @@ end
 const hash_0_imags = hash.(0, h_imags)
 
 function Base.hash(z::Quaternion, h::UInt)
-    hash(real(z), h ⊻ ⊻(hash.(imag_part(z), h_imags)...) ⊻ ⊻(hash_0_imags...))
+    hash(real(z), h ⊻ xor(xor.(hash.(imag_part(z), h_imags), hash_0_imags)...))
 end
 
 """

--- a/src/Quaternion.jl
+++ b/src/Quaternion.jl
@@ -236,6 +236,17 @@ function Base.isequal(q::Quaternion, w::Quaternion)
     isequal(q.s, w.s) & isequal(q.v1, w.v1) & isequal(q.v2, w.v2) & isequal(q.v3, w.v3)
 end
 
+if UInt === UInt64
+    const h_imags = 0xfa29df508725c1bf, 0x5e6c4b26a400626d, 0x8dfd375bac9f9403
+else
+    const h_imags = 0x62802719, 0x5a9b072e, 0x209019b1
+end
+const hash_0_imags = hash.(0, h_imags)
+
+function Base.hash(z::Quaternion, h::UInt)
+    hash(real(z), h ⊻ ⊻(hash.(imag_part(z), h_imags)...) ⊻ ⊻(hash_0_imags...))
+end
+
 """
     extend_analytic(f, q::Quaternion)
 

--- a/test/Quaternion.jl
+++ b/test/Quaternion.jl
@@ -66,6 +66,16 @@ end
         @test !isequal(Quaternion(NaN, 0.0, Inf, -Inf), Quaternion(NaN, -0.0, Inf, -Inf))
     end
 
+    @testset "hash" begin
+        # https://github.com/JuliaGeometry/Quaternions.jl/issues/135
+        @test hash(0) == hash(quat(0)) == hash(0.0) == hash(quat(0.0))
+        @test hash(1) == hash(quat(1)) == hash(1.0) == hash(quat(1.0))
+        @test hash(quat(-0.0)) ≠ hash(quat(+0.0))
+        @test allunique([hash(quat(1,0,0,0)), hash(quat(0,1,0,0)), hash(quat(0,0,1,0)), hash(quat(0,0,0,1))])
+        @test hash(57, UInt(42)) == hash(quat(57), UInt(42))
+        @test length(unique(Quaternion[quat(2), quat(big"2")])) == 1
+    end
+
     @testset "convert" begin
         @test convert(Quaternion{Float64}, 1) === Quaternion(1.0)
         @test convert(Quaternion{Float64}, Quaternion(1, 2, 3, 4)) ===

--- a/test/Quaternion.jl
+++ b/test/Quaternion.jl
@@ -68,11 +68,11 @@ end
 
     @testset "hash" begin
         # https://github.com/JuliaGeometry/Quaternions.jl/issues/135
-        @test hash(0) == hash(quat(0)) == hash(0.0) == hash(quat(0.0))
-        @test hash(1) == hash(quat(1)) == hash(1.0) == hash(quat(1.0))
+        @test hash(0) === hash(quat(0)) === hash(0.0) === hash(quat(0.0))
+        @test hash(1) === hash(quat(1)) === hash(1.0) === hash(quat(1.0))
         @test hash(quat(-0.0)) ≠ hash(quat(+0.0))
         @test allunique([hash(quat(1,0,0,0)), hash(quat(0,1,0,0)), hash(quat(0,0,1,0)), hash(quat(0,0,0,1))])
-        @test hash(57, UInt(42)) == hash(quat(57), UInt(42))
+        @test hash(57, UInt(42)) === hash(quat(57), UInt(42))
         @test length(unique(Quaternion[quat(2), quat(big"2")])) == 1
     end
 


### PR DESCRIPTION
This PR fixes #135.

**Before this PR**
```julia
julia> using Quaternions

julia> isequal(1, complex(1))
true

julia> 1 |> hash
0x5bca7c69b794f8ce

julia> complex(1) |> hash
0x5bca7c69b794f8ce

julia> isequal(1, quat(1))  # isequal(a,b) == true should imply `hash(a) == hash(b)`
true

julia> quat(1) |> hash
0x37cb992a8d339608

julia> unique(Complex[complex(2), complex(big"2")])
1-element Vector{Complex}:
 2 + 0im

julia> unique(Quaternion[quat(2), quat(big"2")])
2-element Vector{Quaternion}:
  Quaternion{Int64}(2, 0, 0, 0)
 Quaternion{BigInt}(2, 0, 0, 0)
```

**After this PR**
```julia
julia> using Quaternions

julia> isequal(1, complex(1))
true

julia> 1 |> hash
0x5bca7c69b794f8ce

julia> complex(1) |> hash
0x5bca7c69b794f8ce

julia> isequal(1, quat(1))  # isequal(a,b) == true should imply `hash(a) == hash(b)`
true

julia> quat(1) |> hash
0x5bca7c69b794f8ce

julia> unique(Complex[complex(2), complex(big"2")])
1-element Vector{Complex}:
 2 + 0im

julia> unique(Quaternion[quat(2), quat(big"2")])
1-element Vector{Quaternion}:
 Quaternion{Int64}(2, 0, 0, 0)
```