### PR TITLE
Add more methods to `Base.:(==)`

### DIFF
--- a/src/Quaternion.jl
+++ b/src/Quaternion.jl
@@ -254,6 +254,11 @@ Base.://(x::Quaternion, y::Real) = quat(real(x)//y, imag_part(x).//y...)
 Base.://(x::Number, y::Quaternion) = x*conj(y)//abs2(y)
 
 Base.:(==)(q::Quaternion, w::Quaternion) = (q.s == w.s) & (q.v1 == w.v1) & (q.v2 == w.v2) & (q.v3 == w.v3)
+Base.:(==)(q::Quaternion, x::Real) = isreal(q) && real(q) == x
+Base.:(==)(x::Real, q::Quaternion) = isreal(q) && real(q) == x
+Base.:(==)(q::Quaternion, z::Complex) = isreal(q) && isreal(z) && real(q) == real(z)
+Base.:(==)(z::Complex, q::Quaternion) = isreal(q) && isreal(z) && real(q) == real(z)
+
 function Base.isequal(q::Quaternion, w::Quaternion)
     isequal(q.s, w.s) & isequal(q.v1, w.v1) & isequal(q.v2, w.v2) & isequal(q.v3, w.v3)
 end

--- a/test/Quaternion.jl
+++ b/test/Quaternion.jl
@@ -57,6 +57,15 @@ end
         @test Quaternion(1, 2, 3, 4) != Quaternion(1, 5, 3, 4)
         @test Quaternion(1, 2, 3, 4) != Quaternion(1, 2, 5, 4)
         @test Quaternion(1, 2, 3, 4) != Quaternion(1, 2, 3, 5)
+
+        @test Quaternion(1, 2, 3, 4) != 1
+        @test Quaternion(1, 0, 0, 0) == 1
+        @test Quaternion(1, 0, 0, 0) != 0
+
+        @test Quaternion(1, 0, 0, 0) == Complex(1, 0)
+        @test Quaternion(1, 0, 0, 0) != Complex(1, 1)
+        @test Quaternion(1, 0, 0, 0) != Complex(0, 1)
+        @test Quaternion(0, 1, 0, 0) != Complex(0, 1)
     end
 
     @testset "isequal" begin
@@ -83,8 +92,6 @@ end
             (Quaternion(1.0, 2, 3, 4), Quaternion(2.0))
         @test promote(Quaternion(1.0f0), Quaternion(2.0)) ===
             (Quaternion(1.0), Quaternion(2.0))
-
-        @test Quaternion(1) == 1.0
     end
 
     @testset "shorthands" begin

--- a/test/Quaternion.jl
+++ b/test/Quaternion.jl
@@ -61,11 +61,18 @@ end
         @test Quaternion(1, 2, 3, 4) != 1
         @test Quaternion(1, 0, 0, 0) == 1
         @test Quaternion(1, 0, 0, 0) != 0
+        @test 1 != Quaternion(1, 2, 3, 4)
+        @test 1 == Quaternion(1, 0, 0, 0)
+        @test 0 != Quaternion(1, 0, 0, 0)
 
         @test Quaternion(1, 0, 0, 0) == Complex(1, 0)
         @test Quaternion(1, 0, 0, 0) != Complex(1, 1)
         @test Quaternion(1, 0, 0, 0) != Complex(0, 1)
         @test Quaternion(0, 1, 0, 0) != Complex(0, 1)
+        @test Complex(1, 0) == Quaternion(1, 0, 0, 0)
+        @test Complex(1, 1) != Quaternion(1, 0, 0, 0)
+        @test Complex(0, 1) != Quaternion(1, 0, 0, 0)
+        @test Complex(0, 1) != Quaternion(0, 1, 0, 0)
     end
 
     @testset "isequal" begin


### PR DESCRIPTION
# Overview

**Before this PR**
```julia
julia> using Quaternions

julia> quat(1) == 1
true

julia> quat(1) == complex(1)
ERROR: promotion of types Quaternion{Int64} and Complex{Int64} failed to change any arguments
Stacktrace:
[...]

julia> quat(1,1,0,0) == complex(1,1)
ERROR: promotion of types Quaternion{Int64} and Complex{Int64} failed to change any arguments
Stacktrace:
[...]
```

**After this PR**
```julia
julia> using Quaternions

julia> quat(1) == 1
true

julia> quat(1) == complex(1)
true

julia> quat(1,1,0,0) == complex(1,1)
false
```

# Why add methods?
Base has the following `==(::Real, ::Complex)` and `==(::Complex, ::Real)` definitions.

https://github.com/JuliaLang/julia/blob/e7345b89fd4eb15e8f395395701e19be705d7b06/base/complex.jl#L247-L249

Quaternions.jl should have methods similar to these, instead of `==` by type promotions.

# How about compatibility with the `Complex` type?
There were the following choices for the design:

* `==(::Complex, ::Quaternion)` always throws an error.
  * The current behavior.
  * I think checking the equality of a complex number and a quaternion is kind of weird, and throwing an error would be a good design.
  * However, most evaluations of `==` do not throw an error (e.g. `"foo" == :foo`), so it would be consistent with Base if we avoid throwing errors for that.
* `==(z::Complex, q::Quaternion)` returns `true` if `c.re==q.s && c.im==q.v1 && q.v2==q.v3==0`, otherwise returns `false`.
  * This is not good because we don't have compatibility with `Complex` (https://github.com/JuliaGeometry/Quaternions.jl/pull/113).
* `==(::Complex, ::Quaternion)` returns `true` only if these are real and equal, otherwise throws an error.
  * Similar to the current behavior, throwing an error should be avoided.
* `==(::Complex, ::Quaternion)` returns `true` only if these are real and equal, otherwise returns `false`.
  * The proposed method definition in this PR.
