### PR TITLE
Run CI on pre-release instead of nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           - '1.0'
           - '1.6'
           - '1' # automatically expands to the latest stable 1.x release of Julia
-          - nightly
+          - 'pre'
         os:
           - ubuntu-latest
         arch:


### PR DESCRIPTION
Since July 26th our CI has [failed on nightly](https://github.com/JuliaGeometry/Quaternions.jl/actions/runs/16534731204/job/46767062990) due to some issue that seems to have nothing to do with our package. This PR drops the nightly test and instead tests against pre-releases, which are more stable and thus more useful to test against.