### PR TITLE
Update Aqua compat to work with Julia v1.12

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Quaternions"
 uuid = "94ee1d12-ae83-5a48-8b1c-48b8ff168ae0"
-version = "0.7.6"
+version = "0.7.7"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -9,10 +9,10 @@ RealDot = "c1ae055f-0cd5-4b69-90a6-9a35b1a98df9"
 
 [compat]
 Aqua = "0.8.13"
-LinearAlgebra = "1"
-Random = "1"
+LinearAlgebra = "<0.0.1, 1"
+Random = "<0.0.1, 1"
 RealDot = "0.1"
-Test = "1"
+Test = "<0.0.1, 1"
 julia = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,10 @@ RealDot = "c1ae055f-0cd5-4b69-90a6-9a35b1a98df9"
 
 [compat]
 Aqua = "0.8.13"
+LinearAlgebra = "1"
+Random = "1"
 RealDot = "0.1"
+Test = "1"
 julia = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RealDot = "c1ae055f-0cd5-4b69-90a6-9a35b1a98df9"
 
 [compat]
-Aqua = "0.7"
+Aqua = "0.8.13"
 RealDot = "0.1"
 julia = "1"
 


### PR DESCRIPTION
The Aqua fix on master needed for our CI to pass on Julia v1.12 (see https://github.com/JuliaGeometry/Quaternions.jl/pull/151#issuecomment-3175284788) was backported to a release, so this PR bumps our Aqua compat to that release.